### PR TITLE
Add backend server, admin panel, and dynamic catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SESSION_SECRET=super-secret-key
+ADMIN_USER=admin
+ADMIN_PASSWORD=admin123
+PORT=3000
+# ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+server/node_modules/
+server/data/
+.env
+server/.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Catálogo Amazonia
+
+Este repositorio contiene un catálogo público de productos de concreto y un panel administrativo para gestionarlo. Incluye un backend en Node.js con SQLite, autenticación basada en sesiones y protección CSRF, así como una SPA ligera para administración y un sitio público que consume el catálogo dinámicamente.
+
+## Requisitos previos
+
+- Node.js 18 o superior
+- npm
+
+## Configuración inicial
+
+1. Instala las dependencias del backend:
+
+   ```bash
+   cd server
+   npm install
+   ```
+
+2. Crea un archivo `.env` (opcional) a partir del ejemplo y ajusta las variables según tus necesidades:
+
+   ```bash
+   cp ../.env.example .env  # opcional: también puedes mantener el .env en la raíz
+   ```
+
+   Variables disponibles:
+
+   | Variable | Descripción |
+   | --- | --- |
+   | `SESSION_SECRET` | Clave usada para firmar la sesión. |
+   | `ADMIN_USER` / `ADMIN_PASSWORD` | Credenciales iniciales para el panel administrativo. |
+   | `PORT` | Puerto donde se expone el backend (por defecto `3000`). |
+   | `ALLOWED_ORIGINS` | Lista separada por comas con los orígenes permitidos para CORS (si el panel se sirve desde otro host). |
+
+3. Ejecuta la migración y seed inicial de la base de datos:
+
+   ```bash
+   npm run migrate
+   ```
+
+   Esto crea las tablas `users`, `categories` y `products`, además de poblarlas con datos de ejemplo y un usuario administrador por defecto (`admin`/`admin123`).
+
+## Ejecución
+
+- **Modo desarrollo** (reinicio automático con `nodemon`):
+
+  ```bash
+  npm run dev
+  ```
+
+- **Modo producción/simple**:
+
+  ```bash
+  npm start
+  ```
+
+El servidor expone:
+
+- Panel administrativo en `http://localhost:<PORT>/admin`
+- Sitio público en `http://localhost:<PORT>/`
+- API REST autenticada en `/api/categories` y `/api/products`
+- Endpoint público `GET /api/catalog` con el catálogo completo para el sitio público
+
+## Panel administrativo
+
+1. Accede a `http://localhost:<PORT>/admin`.
+2. Inicia sesión con las credenciales configuradas (por defecto `admin` / `admin123`).
+3. Gestiona categorías y productos mediante los formularios disponibles. Todos los cambios requieren un token CSRF válido, que la SPA solicita automáticamente.
+
+La aplicación usa `fetch` con `credentials: 'include'`, por lo que si sirves el panel desde otro dominio asegúrate de configurar `ALLOWED_ORIGINS` y los encabezados CORS correspondientes.
+
+## API principal
+
+Todos los endpoints (excepto `GET /api/catalog`) están protegidos por sesión y requieren el token CSRF en el encabezado `X-CSRF-Token` para peticiones de escritura.
+
+| Método | Ruta | Descripción |
+| --- | --- | --- |
+| `GET` | `/api/catalog` | Catálogo completo (categorías + productos) para el sitio público. |
+| `POST` | `/api/auth/login` | Inicia sesión de administrador. |
+| `POST` | `/api/auth/logout` | Cierra sesión. |
+| `GET` | `/api/auth/csrf` | Obtiene un token CSRF válido. |
+| `GET` | `/api/auth/session` | Estado de autenticación actual. |
+| `GET/POST/PUT/DELETE` | `/api/categories` | CRUD de categorías (requiere sesión). |
+| `GET/POST/PUT/DELETE` | `/api/products` | CRUD de productos (requiere sesión). |
+
+## Estructura de carpetas
+
+```
+.
+├── admin/              # SPA administrativa (HTML, CSS, JS)
+├── server/             # Backend en Node.js/Express + SQLite
+│   ├── db/             # Configuración de la base de datos y migraciones
+│   ├── middleware/     # Middlewares personalizados
+│   ├── routes/         # Rutas REST (auth, categories, products)
+│   ├── scripts/        # Scripts auxiliares (migraciones)
+│   └── index.js        # Punto de entrada del servidor
+├── index.html          # Sitio público (consume /api/catalog)
+├── .env.example        # Variables de entorno sugeridas
+└── README.md
+```
+
+## Notas adicionales
+
+- La base de datos SQLite se almacena en `server/data/catalog.db`. Esta ruta está ignorada en Git.
+- Para cambiar las credenciales del administrador crea tu propio usuario en la tabla `users` o modifica las variables `ADMIN_USER` y `ADMIN_PASSWORD` antes de ejecutar la migración.
+- El backend habilita CORS condicionalmente según la variable `ALLOWED_ORIGINS`. Si no se define, se permite el origen de la propia petición.

--- a/admin/app.js
+++ b/admin/app.js
@@ -1,0 +1,514 @@
+const state = {
+  csrfToken: null,
+  categories: [],
+  products: [],
+  editingCategoryId: null,
+  editingProductId: null,
+  selectedCategoryFilter: 'all',
+  user: null
+};
+
+const selectors = {
+  loginView: document.getElementById('login-view'),
+  loginForm: document.getElementById('login-form'),
+  loginError: document.getElementById('login-error'),
+  loginSubmit: document.getElementById('login-submit'),
+  adminView: document.getElementById('admin-view'),
+  sessionUsername: document.getElementById('session-username'),
+  logoutButton: document.getElementById('logout-button'),
+  categoryForm: document.getElementById('category-form'),
+  categoryId: document.getElementById('category-id'),
+  categoryName: document.getElementById('category-name'),
+  categorySlug: document.getElementById('category-slug'),
+  categoryDescription: document.getElementById('category-description'),
+  categorySubmit: document.getElementById('category-submit'),
+  categoryMessage: document.getElementById('category-message'),
+  categoryList: document.getElementById('category-list'),
+  categoryReset: document.getElementById('category-reset'),
+  productForm: document.getElementById('product-form'),
+  productId: document.getElementById('product-id'),
+  productName: document.getElementById('product-name'),
+  productSlug: document.getElementById('product-slug'),
+  productCategory: document.getElementById('product-category'),
+  productIcon: document.getElementById('product-icon'),
+  productPrice: document.getElementById('product-price'),
+  productImage: document.getElementById('product-image'),
+  productDescription: document.getElementById('product-description'),
+  productSpecs: document.getElementById('product-specs'),
+  productSubmit: document.getElementById('product-submit'),
+  productMessage: document.getElementById('product-message'),
+  productList: document.getElementById('product-list'),
+  productReset: document.getElementById('product-reset'),
+  productFilter: document.getElementById('product-filter'),
+  categoryTemplate: document.getElementById('category-item-template'),
+  productTemplate: document.getElementById('product-card-template')
+};
+
+function showMessage(element, message, isError = false) {
+  if (!element) return;
+  element.textContent = message;
+  element.classList.toggle('error', Boolean(isError));
+  element.hidden = !message;
+}
+
+async function fetchCsrfToken(force = false) {
+  if (state.csrfToken && !force) {
+    return state.csrfToken;
+  }
+  const response = await fetch('/api/auth/csrf', { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error('No se pudo obtener el token CSRF.');
+  }
+  const data = await response.json();
+  state.csrfToken = data.csrfToken;
+  return state.csrfToken;
+}
+
+async function apiFetch(url, options = {}) {
+  const method = (options.method || 'GET').toUpperCase();
+  const init = {
+    method,
+    credentials: 'include',
+    headers: { ...(options.headers || {}) }
+  };
+
+  if (options.body !== undefined) {
+    init.body = typeof options.body === 'string' ? options.body : JSON.stringify(options.body);
+    init.headers['Content-Type'] = init.headers['Content-Type'] || 'application/json';
+  }
+
+  if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+    if (!state.csrfToken) {
+      await fetchCsrfToken();
+    }
+    init.headers['X-CSRF-Token'] = state.csrfToken;
+  }
+
+  const response = await fetch(url, init);
+  let data = null;
+  const text = await response.text();
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (error) {
+      console.error('No se pudo parsear la respuesta JSON', error);
+    }
+  }
+
+  if (!response.ok) {
+    if (response.status === 403) {
+      await fetchCsrfToken(true);
+    }
+    const message = data?.error || 'Ocurrió un error inesperado.';
+    throw new Error(message);
+  }
+
+  if (data && data.csrfToken) {
+    state.csrfToken = data.csrfToken;
+  }
+
+  return data;
+}
+
+function toggleView(authenticated) {
+  if (authenticated) {
+    selectors.loginView.classList.add('hidden');
+    selectors.adminView.classList.remove('hidden');
+  } else {
+    selectors.adminView.classList.add('hidden');
+    selectors.loginView.classList.remove('hidden');
+  }
+}
+
+async function checkSession() {
+  try {
+    const response = await fetch('/api/auth/session', { credentials: 'include' });
+    if (!response.ok) {
+      throw new Error('Sesión inválida');
+    }
+    return await response.json();
+  } catch (error) {
+    return { authenticated: false };
+  }
+}
+
+function resetCategoryForm() {
+  state.editingCategoryId = null;
+  selectors.categoryId.value = '';
+  selectors.categoryName.value = '';
+  selectors.categorySlug.value = '';
+  selectors.categoryDescription.value = '';
+  selectors.categorySubmit.textContent = 'Guardar categoría';
+  showMessage(selectors.categoryMessage, '');
+}
+
+function resetProductForm() {
+  state.editingProductId = null;
+  selectors.productId.value = '';
+  selectors.productName.value = '';
+  selectors.productSlug.value = '';
+  selectors.productIcon.value = '';
+  selectors.productPrice.value = '';
+  selectors.productImage.value = '';
+  selectors.productDescription.value = '';
+  selectors.productSpecs.value = '';
+  selectors.productSubmit.textContent = 'Guardar producto';
+  if (state.categories.length > 0) {
+    selectors.productCategory.value = String(state.categories[0].id);
+  }
+  showMessage(selectors.productMessage, '');
+}
+
+function specsToTextarea(specs) {
+  if (!Array.isArray(specs)) return '';
+  return specs.map(([label, value]) => `${label}: ${value}`).join('\n');
+}
+
+function populateCategoryOptions() {
+  const filterSelect = selectors.productFilter;
+  const categorySelect = selectors.productCategory;
+
+  filterSelect.innerHTML = '';
+  const allOption = document.createElement('option');
+  allOption.value = 'all';
+  allOption.textContent = 'Todas las categorías';
+  filterSelect.appendChild(allOption);
+
+  categorySelect.innerHTML = '';
+
+  state.categories.forEach((category) => {
+    const option = document.createElement('option');
+    option.value = String(category.id);
+    option.textContent = category.name;
+    filterSelect.appendChild(option.cloneNode(true));
+    categorySelect.appendChild(option);
+  });
+
+  if (!state.categories.some((cat) => String(cat.id) === state.selectedCategoryFilter)) {
+    state.selectedCategoryFilter = 'all';
+  }
+
+  filterSelect.value = state.selectedCategoryFilter;
+  if (state.categories.length > 0) {
+    categorySelect.value = String(state.categories[0].id);
+  }
+}
+
+function renderCategories() {
+  selectors.categoryList.innerHTML = '';
+
+  state.categories.forEach((category) => {
+    const template = selectors.categoryTemplate.content.cloneNode(true);
+    const listItem = template.querySelector('.list-item');
+    listItem.dataset.id = category.id;
+
+    template.querySelector('.item-title').textContent = category.name;
+    template.querySelector('.item-subtitle').textContent = category.description || 'Sin descripción';
+
+    template.querySelector('.item-edit').addEventListener('click', () => {
+      state.editingCategoryId = category.id;
+      selectors.categoryId.value = String(category.id);
+      selectors.categoryName.value = category.name;
+      selectors.categorySlug.value = category.slug || '';
+      selectors.categoryDescription.value = category.description || '';
+      selectors.categorySubmit.textContent = 'Actualizar categoría';
+      selectors.categoryName.focus();
+    });
+
+    template.querySelector('.item-delete').addEventListener('click', async () => {
+      const confirmed = window.confirm(`¿Eliminar la categoría "${category.name}"? Los productos asociados también se eliminarán.`);
+      if (!confirmed) return;
+      try {
+        selectors.categorySubmit.disabled = true;
+        selectors.productSubmit.disabled = true;
+        await apiFetch(`/api/categories/${category.id}`, { method: 'DELETE' });
+        await loadAdminData();
+        resetCategoryForm();
+        resetProductForm();
+      } catch (error) {
+        showMessage(selectors.categoryMessage, error.message, true);
+      } finally {
+        selectors.categorySubmit.disabled = false;
+        selectors.productSubmit.disabled = false;
+      }
+    });
+
+    selectors.categoryList.appendChild(template);
+  });
+}
+
+function renderProducts() {
+  selectors.productList.innerHTML = '';
+  const filter = state.selectedCategoryFilter;
+
+  const filteredProducts = state.products.filter((product) => {
+    if (filter === 'all') return true;
+    return String(product.categoryId) === filter;
+  });
+
+  if (filteredProducts.length === 0) {
+    const emptyState = document.createElement('p');
+    emptyState.textContent = 'No hay productos registrados para esta categoría.';
+    emptyState.className = 'subtitle';
+    selectors.productList.appendChild(emptyState);
+    return;
+  }
+
+  filteredProducts.forEach((product) => {
+    const template = selectors.productTemplate.content.cloneNode(true);
+    const card = template.querySelector('.product-card');
+    card.dataset.id = product.id;
+
+    template.querySelector('.product-icon').textContent = product.icon || '🏷️';
+    template.querySelector('.product-title').textContent = product.name;
+
+    const category = state.categories.find((cat) => cat.id === product.categoryId);
+    const metaParts = [];
+    if (category) {
+      metaParts.push(category.name);
+    }
+    if (product.price !== null && product.price !== undefined) {
+      metaParts.push(`Precio: ${Number(product.price).toLocaleString('es-ES', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      })}`);
+    }
+    if (product.imageUrl) {
+      metaParts.push('Con imagen');
+    }
+    template.querySelector('.product-meta').textContent = metaParts.join(' · ');
+    template.querySelector('.product-description').textContent = product.description || 'Sin descripción disponible.';
+
+    const specsList = template.querySelector('.product-specs');
+    if (Array.isArray(product.specs) && product.specs.length > 0) {
+      product.specs.forEach(([label, value]) => {
+        const item = document.createElement('li');
+        const labelElement = document.createElement('strong');
+        labelElement.textContent = label;
+        const valueElement = document.createElement('span');
+        valueElement.textContent = value;
+        item.appendChild(labelElement);
+        item.appendChild(valueElement);
+        specsList.appendChild(item);
+      });
+    } else {
+      const emptySpecs = document.createElement('li');
+      emptySpecs.textContent = 'Sin especificaciones.';
+      specsList.appendChild(emptySpecs);
+    }
+
+    template.querySelector('.product-edit').addEventListener('click', () => {
+      state.editingProductId = product.id;
+      selectors.productId.value = String(product.id);
+      selectors.productName.value = product.name;
+      selectors.productSlug.value = product.slug || '';
+      selectors.productCategory.value = String(product.categoryId);
+      selectors.productIcon.value = product.icon || '';
+      selectors.productPrice.value = product.price ?? '';
+      selectors.productImage.value = product.imageUrl || '';
+      selectors.productDescription.value = product.description || '';
+      selectors.productSpecs.value = specsToTextarea(product.specs);
+      selectors.productSubmit.textContent = 'Actualizar producto';
+      selectors.productName.focus();
+    });
+
+    template.querySelector('.product-delete').addEventListener('click', async () => {
+      const confirmed = window.confirm(`¿Eliminar el producto "${product.name}"?`);
+      if (!confirmed) return;
+      try {
+        selectors.productSubmit.disabled = true;
+        await apiFetch(`/api/products/${product.id}`, { method: 'DELETE' });
+        await fetchProducts();
+        resetProductForm();
+      } catch (error) {
+        showMessage(selectors.productMessage, error.message, true);
+      } finally {
+        selectors.productSubmit.disabled = false;
+      }
+    });
+
+    selectors.productList.appendChild(template);
+  });
+}
+
+async function fetchCategories() {
+  const data = await apiFetch('/api/categories');
+  state.categories = data?.categories || [];
+  populateCategoryOptions();
+  renderCategories();
+}
+
+async function fetchProducts() {
+  const data = await apiFetch('/api/products');
+  state.products = data?.products?.map((product) => ({
+    ...product,
+    specs: product.specs || []
+  })) || [];
+  renderProducts();
+}
+
+async function loadAdminData() {
+  await Promise.all([fetchCategories(), fetchProducts()]);
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  showMessage(selectors.loginError, '');
+  selectors.loginSubmit.disabled = true;
+  selectors.loginSubmit.textContent = 'Ingresando...';
+
+  const formData = new FormData(selectors.loginForm);
+  const username = formData.get('username');
+  const password = formData.get('password');
+
+  try {
+    await fetchCsrfToken();
+    const data = await apiFetch('/api/auth/login', {
+      method: 'POST',
+      body: { username, password }
+    });
+    state.user = data.user;
+    await fetchCsrfToken(true);
+    selectors.sessionUsername.textContent = `Hola, ${data.user.username}`;
+    toggleView(true);
+    resetCategoryForm();
+    resetProductForm();
+    await loadAdminData();
+  } catch (error) {
+    showMessage(selectors.loginError, error.message, true);
+  } finally {
+    selectors.loginSubmit.disabled = false;
+    selectors.loginSubmit.textContent = 'Ingresar';
+    selectors.loginForm.reset();
+  }
+}
+
+async function handleLogout() {
+  try {
+    await apiFetch('/api/auth/logout', { method: 'POST' });
+  } catch (error) {
+    console.error('Error al cerrar sesión', error);
+  } finally {
+    state.user = null;
+    state.csrfToken = null;
+    state.categories = [];
+    state.products = [];
+    toggleView(false);
+    showMessage(selectors.loginError, 'Sesión finalizada. Inicia sesión nuevamente.');
+  }
+}
+
+selectors.loginForm.addEventListener('submit', handleLogin);
+selectors.logoutButton.addEventListener('click', handleLogout);
+
+selectors.categoryForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  showMessage(selectors.categoryMessage, '');
+
+  const name = selectors.categoryName.value.trim();
+  const slug = selectors.categorySlug.value.trim();
+  const description = selectors.categoryDescription.value.trim();
+  const body = {
+    name,
+    description: description || undefined
+  };
+
+  if (slug) {
+    body.slug = slug;
+  }
+
+  const isEditing = Boolean(state.editingCategoryId);
+  const url = isEditing ? `/api/categories/${state.editingCategoryId}` : '/api/categories';
+  const method = isEditing ? 'PUT' : 'POST';
+
+  selectors.categorySubmit.disabled = true;
+  selectors.categorySubmit.textContent = isEditing ? 'Actualizando...' : 'Guardando...';
+
+  try {
+    await apiFetch(url, { method, body });
+    await fetchCategories();
+    resetCategoryForm();
+    showMessage(selectors.categoryMessage, 'Categoría guardada correctamente.');
+    await fetchProducts();
+  } catch (error) {
+    showMessage(selectors.categoryMessage, error.message, true);
+  } finally {
+    selectors.categorySubmit.disabled = false;
+    selectors.categorySubmit.textContent = 'Guardar categoría';
+  }
+});
+
+selectors.categoryReset.addEventListener('click', resetCategoryForm);
+
+selectors.productForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  showMessage(selectors.productMessage, '');
+
+  const body = {
+    name: selectors.productName.value.trim(),
+    slug: selectors.productSlug.value.trim() || undefined,
+    categoryId: selectors.productCategory.value,
+    icon: selectors.productIcon.value.trim() || undefined,
+    imageUrl: selectors.productImage.value.trim() || undefined,
+    description: selectors.productDescription.value.trim(),
+    specs: selectors.productSpecs.value
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [label, ...valueParts] = line.split(':');
+        if (!label || valueParts.length === 0) return null;
+        return [label.trim(), valueParts.join(':').trim()];
+      })
+      .filter(Boolean)
+  };
+
+  const priceValue = selectors.productPrice.value.trim();
+  if (priceValue !== '') {
+    body.price = priceValue;
+  }
+
+  if (body.specs.length === 0) {
+    delete body.specs;
+  }
+
+  const isEditing = Boolean(state.editingProductId);
+  const url = isEditing ? `/api/products/${state.editingProductId}` : '/api/products';
+  const method = isEditing ? 'PUT' : 'POST';
+
+  selectors.productSubmit.disabled = true;
+  selectors.productSubmit.textContent = isEditing ? 'Actualizando...' : 'Guardando...';
+
+  try {
+    await apiFetch(url, { method, body });
+    await fetchProducts();
+    resetProductForm();
+    showMessage(selectors.productMessage, 'Producto guardado correctamente.');
+  } catch (error) {
+    showMessage(selectors.productMessage, error.message, true);
+  } finally {
+    selectors.productSubmit.disabled = false;
+    selectors.productSubmit.textContent = 'Guardar producto';
+  }
+});
+
+selectors.productReset.addEventListener('click', resetProductForm);
+
+selectors.productFilter.addEventListener('change', (event) => {
+  state.selectedCategoryFilter = event.target.value;
+  renderProducts();
+});
+
+(async function init() {
+  const session = await checkSession();
+  if (session.authenticated) {
+    state.user = session.user;
+    selectors.sessionUsername.textContent = `Hola, ${session.user.username}`;
+    toggleView(true);
+    await fetchCsrfToken().catch(() => {});
+    await loadAdminData();
+  } else {
+    toggleView(false);
+    await fetchCsrfToken().catch(() => {});
+  }
+})();

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Panel administrativo | Catálogo Amazonia</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main id="app">
+    <section id="login-view" class="card">
+      <h1>Panel administrativo</h1>
+      <p class="subtitle">Inicia sesión para gestionar el catálogo.</p>
+      <form id="login-form" class="form">
+        <label for="login-username">Usuario</label>
+        <input type="text" id="login-username" name="username" autocomplete="username" required>
+
+        <label for="login-password">Contraseña</label>
+        <input type="password" id="login-password" name="password" autocomplete="current-password" required>
+
+        <button type="submit" class="primary" id="login-submit">Ingresar</button>
+        <p id="login-error" class="message error" role="alert" hidden></p>
+      </form>
+    </section>
+
+    <section id="admin-view" class="hidden">
+      <header class="top-bar">
+        <div>
+          <h1>Catálogo Amazonia</h1>
+          <p class="subtitle">Gestiona categorías y productos del catálogo público.</p>
+        </div>
+        <div class="session-info">
+          <span id="session-username"></span>
+          <button id="logout-button" class="secondary">Cerrar sesión</button>
+        </div>
+      </header>
+
+      <div class="grid">
+        <section class="card">
+          <header class="section-header">
+            <div>
+              <h2>Categorías</h2>
+              <p class="subtitle">Crea y organiza tus categorías.</p>
+            </div>
+            <button id="category-reset" class="link" type="button">Nueva categoría</button>
+          </header>
+
+          <form id="category-form" class="form">
+            <input type="hidden" id="category-id">
+
+            <label for="category-name">Nombre</label>
+            <input type="text" id="category-name" required>
+
+            <label for="category-slug">Slug (opcional)</label>
+            <input type="text" id="category-slug" placeholder="macetas">
+
+            <label for="category-description">Descripción</label>
+            <textarea id="category-description" rows="3" placeholder="Describe brevemente la categoría"></textarea>
+
+            <button type="submit" class="primary" id="category-submit">Guardar categoría</button>
+            <p id="category-message" class="message" hidden></p>
+          </form>
+
+          <ul id="category-list" class="list"></ul>
+        </section>
+
+        <section class="card">
+          <header class="section-header">
+            <div>
+              <h2>Productos</h2>
+              <p class="subtitle">Gestiona los productos y sus especificaciones.</p>
+            </div>
+            <button id="product-reset" class="link" type="button">Nuevo producto</button>
+          </header>
+
+          <div class="filters">
+            <label for="product-filter">Filtrar por categoría</label>
+            <select id="product-filter"></select>
+          </div>
+
+          <form id="product-form" class="form">
+            <input type="hidden" id="product-id">
+
+            <label for="product-name">Nombre</label>
+            <input type="text" id="product-name" required>
+
+            <label for="product-slug">Slug (opcional)</label>
+            <input type="text" id="product-slug" placeholder="maceta-tropical">
+
+            <label for="product-category">Categoría</label>
+            <select id="product-category" required></select>
+
+            <label for="product-icon">Icono (emoji opcional)</label>
+            <input type="text" id="product-icon" maxlength="4" placeholder="🪴">
+
+            <label for="product-price">Precio (opcional)</label>
+            <input type="number" id="product-price" step="0.01" min="0" placeholder="0.00">
+
+            <label for="product-image">URL de imagen (opcional)</label>
+            <input type="url" id="product-image" placeholder="https://...">
+
+            <label for="product-description">Descripción</label>
+            <textarea id="product-description" rows="3" required></textarea>
+
+            <label for="product-specs">Especificaciones (una por línea, formato: etiqueta: valor)</label>
+            <textarea id="product-specs" rows="6" placeholder="Material: Concreto reforzado"></textarea>
+
+            <button type="submit" class="primary" id="product-submit">Guardar producto</button>
+            <p id="product-message" class="message" hidden></p>
+          </form>
+
+          <div id="product-list" class="list products"></div>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <template id="category-item-template">
+    <li class="list-item">
+      <div class="item-body">
+        <h3 class="item-title"></h3>
+        <p class="item-subtitle"></p>
+      </div>
+      <div class="item-actions">
+        <button class="secondary item-edit">Editar</button>
+        <button class="danger item-delete">Eliminar</button>
+      </div>
+    </li>
+  </template>
+
+  <template id="product-card-template">
+    <article class="product-card">
+      <header>
+        <span class="product-icon"></span>
+        <div>
+          <h3 class="product-title"></h3>
+          <p class="product-meta"></p>
+        </div>
+      </header>
+      <p class="product-description"></p>
+      <ul class="product-specs"></ul>
+      <footer class="item-actions">
+        <button class="secondary product-edit">Editar</button>
+        <button class="danger product-delete">Eliminar</button>
+      </footer>
+    </article>
+  </template>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/admin/styles.css
+++ b/admin/styles.css
@@ -1,0 +1,284 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(30, 64, 175, 0.4), transparent 55%), #0f172a;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem 1rem 4rem;
+}
+
+#app {
+  width: min(1100px, 100%);
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.hidden {
+  display: none;
+}
+
+h1, h2, h3 {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0 0 1.5rem;
+  color: #94a3b8;
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+label {
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+input,
+textarea,
+select,
+button {
+  font: inherit;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.65);
+  color: #f1f5f9;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button:active {
+  transform: scale(0.97);
+}
+
+.primary {
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+  color: #0b1120;
+  font-weight: 600;
+  box-shadow: 0 8px 25px rgba(37, 99, 235, 0.35);
+}
+
+.secondary {
+  background: rgba(226, 232, 240, 0.1);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.link {
+  background: none;
+  color: #38bdf8;
+  padding: 0;
+  border: none;
+  font-weight: 600;
+}
+
+.message {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #38bdf8;
+}
+
+.message.error {
+  color: #f87171;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.session-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #cbd5f5;
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .grid {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.list-item,
+.product-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.item-body {
+  flex: 1;
+}
+
+.item-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+}
+
+.item-subtitle {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.item-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.product-card {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.product-card header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.product-icon {
+  font-size: 1.5rem;
+}
+
+.product-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.product-meta {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.product-description {
+  margin: 0 0 0.75rem;
+  color: #cbd5f5;
+  line-height: 1.4;
+}
+
+.product-specs {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.product-specs li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.product-specs span {
+  color: #94a3b8;
+}
+
+.products .product-card {
+  border: 1px solid rgba(56, 189, 248, 0.2);
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.5rem 0.75rem;
+  }
+
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .item-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -119,7 +119,29 @@
             flex-wrap: wrap;
         }
 
-        .nav-btn {
+        
+        .nav-placeholder {
+            width: 100%;
+            text-align: center;
+            color: #6b7280;
+            font-weight: 500;
+        }
+
+        .loading-message {
+            text-align: center;
+            color: #6b7280;
+            padding: 2rem 0;
+            font-weight: 500;
+        }
+
+        .error-message {
+            text-align: center;
+            color: #b91c1c;
+            padding: 2rem 0;
+            font-weight: 600;
+        }
+
+.nav-btn {
             padding: 0.7rem 1.5rem;
             background: linear-gradient(135deg, #6b8e68 0%, #8fa68c 100%);
             color: white;
@@ -582,213 +604,16 @@
     <!-- Navigation -->
     <div class="nav-container">
         <nav>
-            <div class="nav-buttons">
-                <button class="nav-btn active" onclick="showCategory('macetas', this)">🪴 Macetas</button>
-                <button class="nav-btn" onclick="showCategory('pisos', this)">⬜ Pisos</button>
-                <button class="nav-btn" onclick="showCategory('revestimientos', this)">🏗️ Revestimientos</button>
-                <button class="nav-btn" onclick="showCategory('mobiliario', this)">🪑 Mobiliario</button>
-                <button class="nav-btn" onclick="showCategory('decoracion', this)">🎨 Decoración</button>
+            <div class="nav-buttons" id="nav-buttons">
+                <p class="nav-placeholder">Cargando catálogo...</p>
             </div>
+
         </nav>
     </div>
 
     <!-- Main Container -->
-    <div class="container">
-        <!-- Macetas Category -->
-        <div class="category active" id="macetas">
-            <h2 class="category-title">Macetas de Concreto</h2>
-            <p class="category-description">Diseños únicos inspirados en la naturaleza amazónica</p>
-            <div class="products-grid">
-                <div class="product-card" onclick="openModal('maceta1')">
-                    <div class="product-image">🪴</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Maceta Tropical</h3>
-                        <p class="product-description">Diseño orgánico con textura de hojas tropicales</p>
-                        <div class="product-features">
-                            <span class="feature-tag">30cm x 25cm</span>
-                            <span class="feature-tag">Interior/Exterior</span>
-                        </div>
-                        <p class="product-price">$45.000</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('maceta2')">
-                    <div class="product-image">🌿</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Maceta Minimalista</h3>
-                        <p class="product-description">Líneas limpias con acabado natural</p>
-                        <div class="product-features">
-                            <span class="feature-tag">20cm x 20cm</span>
-                            <span class="feature-tag">Drenaje incluido</span>
-                        </div>
-                        <p class="product-price">$35.000</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('maceta3')">
-                    <div class="product-image">🌱</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Set Jardín Vertical</h3>
-                        <p class="product-description">Sistema modular para crear tu propio jardín vertical</p>
-                        <div class="product-features">
-                            <span class="feature-tag">3 piezas</span>
-                            <span class="feature-tag">Montaje en pared</span>
-                        </div>
-                        <p class="product-price">$120.000</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Pisos Category -->
-        <div class="category" id="pisos">
-            <h2 class="category-title">Pisos de Concreto</h2>
-            <p class="category-description">Resistencia y elegancia para tus espacios</p>
-            <div class="products-grid">
-                <div class="product-card" onclick="openModal('piso1')">
-                    <div class="product-image">⬜</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Baldosa Amazonia</h3>
-                        <p class="product-description">Patrón de hojas en relieve sutil</p>
-                        <div class="product-features">
-                            <span class="feature-tag">40cm x 40cm</span>
-                            <span class="feature-tag">Antideslizante</span>
-                        </div>
-                        <p class="product-price">$85.000/m²</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('piso2')">
-                    <div class="product-image">⬛</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Concreto Pulido</h3>
-                        <p class="product-description">Acabado espejo con sellador ecológico</p>
-                        <div class="product-features">
-                            <span class="feature-tag">Personalizable</span>
-                            <span class="feature-tag">Alta durabilidad</span>
-                        </div>
-                        <p class="product-price">$120.000/m²</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('piso3')">
-                    <div class="product-image">🔲</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Adoquín Ecológico</h3>
-                        <p class="product-description">Permeable para jardines y exteriores</p>
-                        <div class="product-features">
-                            <span class="feature-tag">20cm x 10cm</span>
-                            <span class="feature-tag">Drenaje natural</span>
-                        </div>
-                        <p class="product-price">$65.000/m²</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Revestimientos Category -->
-        <div class="category" id="revestimientos">
-            <h2 class="category-title">Revestimientos</h2>
-            <p class="category-description">Transforma tus paredes con texturas naturales</p>
-            <div class="products-grid">
-                <div class="product-card" onclick="openModal('revest1')">
-                    <div class="product-image">🏗️</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Panel 3D Selva</h3>
-                        <p class="product-description">Relieve tridimensional inspirado en la selva</p>
-                        <div class="product-features">
-                            <span class="feature-tag">60cm x 60cm</span>
-                            <span class="feature-tag">Interior</span>
-                        </div>
-                        <p class="product-price">$95.000/panel</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('revest2')">
-                    <div class="product-image">🧱</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Ladrillo Aparente</h3>
-                        <p class="product-description">Estilo industrial con toque natural</p>
-                        <div class="product-features">
-                            <span class="feature-tag">Varios colores</span>
-                            <span class="feature-tag">Fácil instalación</span>
-                        </div>
-                        <p class="product-price">$75.000/m²</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Mobiliario Category -->
-        <div class="category" id="mobiliario">
-            <h2 class="category-title">Mobiliario de Concreto</h2>
-            <p class="category-description">Piezas únicas y duraderas para tu hogar</p>
-            <div class="products-grid">
-                <div class="product-card" onclick="openModal('mueble1')">
-                    <div class="product-image">🪑</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Banca Jardín</h3>
-                        <p class="product-description">Diseño ergonómico con respaldo de hojas</p>
-                        <div class="product-features">
-                            <span class="feature-tag">150cm largo</span>
-                            <span class="feature-tag">Resistente UV</span>
-                        </div>
-                        <p class="product-price">$450.000</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('mueble2')">
-                    <div class="product-image">🪜</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Mesa Centro</h3>
-                        <p class="product-description">Diseño minimalista con base de concreto</p>
-                        <div class="product-features">
-                            <span class="feature-tag">100cm x 60cm</span>
-                            <span class="feature-tag">Tope de vidrio</span>
-                        </div>
-                        <p class="product-price">$580.000</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Decoración Category -->
-        <div class="category" id="decoracion">
-            <h2 class="category-title">Decoración</h2>
-            <p class="category-description">Detalles que marcan la diferencia</p>
-            <div class="products-grid">
-                <div class="product-card" onclick="openModal('deco1')">
-                    <div class="product-image">🎨</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Escultura Hoja</h3>
-                        <p class="product-description">Pieza decorativa con detalle botánico</p>
-                        <div class="product-features">
-                            <span class="feature-tag">30cm altura</span>
-                            <span class="feature-tag">Edición limitada</span>
-                        </div>
-                        <p class="product-price">$180.000</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('deco2')">
-                    <div class="product-image">🕯️</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Portavelas Natural</h3>
-                        <p class="product-description">Set de 3 portavelas con textura orgánica</p>
-                        <div class="product-features">
-                            <span class="feature-tag">3 tamaños</span>
-                            <span class="feature-tag">Acabado mate</span>
-                        </div>
-                        <p class="product-price">$65.000</p>
-                    </div>
-                </div>
-                <div class="product-card" onclick="openModal('deco3')">
-                    <div class="product-image">🖼️</div>
-                    <div class="product-info">
-                        <h3 class="product-name">Mural Relieve</h3>
-                        <p class="product-description">Arte en concreto para tu pared</p>
-                        <div class="product-features">
-                            <span class="feature-tag">80cm x 60cm</span>
-                            <span class="feature-tag">Personalizable</span>
-                        </div>
-                        <p class="product-price">$320.000</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div class="container" id="catalog-container">
+        <p class="loading-message">Cargando catálogo...</p>
     </div>
 
     <!-- Modal -->
@@ -840,296 +665,314 @@
     </footer>
 
     <script>
-        // Variables globales
         let currentProduct = null;
-        
-        // Datos de productos expandidos
-        const productData = {
-            maceta1: {
-                title: 'Maceta Tropical',
-                icon: '🪴',
-                description: 'Nuestra maceta tropical está inspirada en las hojas del Amazonas. Cada pieza es única, con texturas que imitan las venas de las hojas tropicales. Perfecta para plantas de interior y exterior, cuenta con sistema de drenaje integrado y acabado resistente a la intemperie.',
-                specs: [
-                    ['Material', 'Concreto reforzado con fibra'],
-                    ['Dimensiones', '30cm x 25cm x 28cm'],
-                    ['Peso', '8 kg'],
-                    ['Colores', 'Gris natural, Verde musgo, Terracota'],
-                    ['Drenaje', 'Sistema integrado con plato'],
-                    ['Garantía', '2 años']
-                ]
-            },
-            maceta2: {
-                title: 'Maceta Minimalista',
-                icon: '🌿',
-                description: 'Diseño contemporáneo que combina la simplicidad con la funcionalidad. Su acabado liso y formas geométricas la convierten en el complemento perfecto para espacios modernos. Ideal para suculentas y cactus.',
-                specs: [
-                    ['Material', 'Concreto pulido'],
-                    ['Dimensiones', '20cm x 20cm x 18cm'],
-                    ['Peso', '4 kg'],
-                    ['Colores', 'Blanco, Gris, Negro'],
-                    ['Acabado', 'Sellador impermeable'],
-                    ['Garantía', '2 años']
-                ]
-            },
-            maceta3: {
-                title: 'Set Jardín Vertical',
-                icon: '🌱',
-                description: 'Sistema modular revolucionario para crear jardines verticales. Cada módulo se conecta fácilmente permitiendo diseños personalizados. Incluye sistema de riego por goteo opcional.',
-                specs: [
-                    ['Material', 'Concreto aligerado'],
-                    ['Módulos', '3 piezas hexagonales'],
-                    ['Dimensiones', '25cm x 22cm cada módulo'],
-                    ['Peso total', '12 kg'],
-                    ['Instalación', 'Incluye kit de montaje'],
-                    ['Garantía', '3 años']
-                ]
-            },
-            piso1: {
-                title: 'Baldosa Amazonia',
-                icon: '⬜',
-                description: 'Baldosas premium con diseño exclusivo de hojas en relieve. Cada baldosa es una obra de arte que combina durabilidad con estética natural. Perfecta para crear caminos orgánicos en jardines o terrazas.',
-                specs: [
-                    ['Material', 'Concreto de alta resistencia'],
-                    ['Dimensiones', '40cm x 40cm x 4cm'],
-                    ['Peso', '12 kg/unidad'],
-                    ['Resistencia', '350 kg/cm²'],
-                    ['Acabado', 'Antideslizante clase 3'],
-                    ['Vida útil', '25+ años']
-                ]
-            },
-            piso2: {
-                title: 'Concreto Pulido',
-                icon: '⬛',
-                description: 'Solución integral de pisos con acabado espejo. Proceso de pulido diamantado que resalta los agregados naturales del concreto. Incluye tratamiento densificador y sellador de última generación.',
-                specs: [
-                    ['Espesor', '10-15cm'],
-                    ['Acabado', 'Pulido diamantado 3000 grit'],
-                    ['Sellador', 'Base agua, bajo VOC'],
-                    ['Mantenimiento', 'Mínimo'],
-                    ['Colores', 'Personalizable con tintes'],
-                    ['Garantía', '10 años']
-                ]
-            },
-            piso3: {
-                title: 'Adoquín Ecológico',
-                icon: '🔲',
-                description: 'Adoquines permeables que permiten la filtración natural del agua. Ideales para proyectos sostenibles y manejo de aguas pluviales. Disponibles en varios patrones de instalación.',
-                specs: [
-                    ['Material', 'Concreto poroso'],
-                    ['Dimensiones', '20cm x 10cm x 8cm'],
-                    ['Permeabilidad', '300 l/m²/min'],
-                    ['Peso', '3.5 kg/unidad'],
-                    ['Resistencia', '280 kg/cm²'],
-                    ['Certificación', 'LEED compatible']
-                ]
-            },
-            revest1: {
-                title: 'Panel 3D Selva',
-                icon: '🏗️',
-                description: 'Paneles decorativos con relieve tridimensional que recrean la exuberancia de la selva amazónica. Cada panel es una pieza única que transforma cualquier pared en una obra de arte.',
-                specs: [
-                    ['Material', 'Concreto arquitectónico'],
-                    ['Dimensiones', '60cm x 60cm x 3cm'],
-                    ['Peso', '15 kg/panel'],
-                    ['Instalación', 'Adhesivo especial incluido'],
-                    ['Acabado', 'Pintura mineral ecológica'],
-                    ['Uso', 'Interior']
-                ]
-            },
-            revest2: {
-                title: 'Ladrillo Aparente',
-                icon: '🧱',
-                description: 'Revestimiento que simula ladrillo expuesto con la durabilidad del concreto. Perfecto para ambientes industriales o rústicos modernos. Disponible en varios tonos y texturas.',
-                specs: [
-                    ['Material', 'Concreto texturizado'],
-                    ['Formato', 'Placas de 50x25cm'],
-                    ['Espesor', '2cm'],
-                    ['Colores', 'Rojo, Café, Gris, Blanco'],
-                    ['Instalación', 'Sistema click o adhesivo'],
-                    ['Rendimiento', '8 placas/m²']
-                ]
-            },
-            mueble1: {
-                title: 'Banca Jardín',
-                icon: '🪑',
-                description: 'Banca escultórica con respaldo inspirado en hojas tropicales. Combina arte y funcionalidad, perfecta como pieza central en jardines o terrazas. Tratamiento anti-UV garantiza colores duraderos.',
-                specs: [
-                    ['Material', 'Concreto reforzado'],
-                    ['Dimensiones', '150cm x 45cm x 85cm'],
-                    ['Peso', '120 kg'],
-                    ['Capacidad', '3 personas (300kg)'],
-                    ['Acabado', 'Hidrofugante y anti-UV'],
-                    ['Anclaje', 'Opcional al piso']
-                ]
-            },
-            mueble2: {
-                title: 'Mesa Centro',
-                icon: '🪜',
-                description: 'Mesa de centro con base escultórica de concreto y tope de vidrio templado. El diseño fluido de la base evoca las formas orgánicas de la naturaleza. Pieza statement para cualquier sala.',
-                specs: [
-                    ['Base', 'Concreto arquitectónico'],
-                    ['Tope', 'Vidrio templado 12mm'],
-                    ['Dimensiones', '100cm x 60cm x 45cm'],
-                    ['Peso', '85 kg'],
-                    ['Capacidad', '50 kg'],
-                    ['Mantenimiento', 'Limpieza con paño húmedo']
-                ]
-            },
-            deco1: {
-                title: 'Escultura Hoja',
-                icon: '🎨',
-                description: 'Escultura artística que captura la elegancia de una hoja amazónica en concreto. Cada pieza es moldeada a mano, garantizando su exclusividad. Incluye base y puede ser personalizada.',
-                specs: [
-                    ['Material', 'Concreto fino'],
-                    ['Altura', '30cm'],
-                    ['Base', '15cm diámetro'],
-                    ['Peso', '3 kg'],
-                    ['Acabado', 'Pátina artística'],
-                    ['Edición', 'Limitada, numerada']
-                ]
-            },
-            deco2: {
-                title: 'Portavelas Natural',
-                icon: '🕯️',
-                description: 'Set de portavelas con textura que imita la corteza de los árboles amazónicos. Crea ambientes cálidos y acogedores. Compatible con velas de té y velas pilares pequeñas.',
-                specs: [
-                    ['Material', 'Concreto texturizado'],
-                    ['Set', '3 piezas (S, M, L)'],
-                    ['Alturas', '5cm, 8cm, 11cm'],
-                    ['Peso total', '2 kg'],
-                    ['Acabado', 'Mate, resistente al calor'],
-                    ['Incluye', 'Velas de muestra']
-                ]
-            },
-            deco3: {
-                title: 'Mural Relieve',
-                icon: '🖼️',
-                description: 'Obra de arte en concreto personalizable. Podemos crear diseños exclusivos basados en tus ideas o elegir de nuestra galería de diseños tropicales. Incluye sistema de montaje invisible.',
-                specs: [
-                    ['Material', 'Concreto artístico'],
-                    ['Dimensiones', '80cm x 60cm x 4cm'],
-                    ['Peso', '25 kg'],
-                    ['Personalización', 'Diseño a medida'],
-                    ['Instalación', 'Kit de montaje oculto'],
-                    ['Tiempo entrega', '15 días']
-                ]
-            }
+        const navButtonsContainer = document.getElementById('nav-buttons');
+        const catalogContainer = document.getElementById('catalog-container');
+        const productModal = document.getElementById('productModal');
+        const modalTitle = document.getElementById('modalTitle');
+        const modalImage = document.getElementById('modalImage');
+        const modalDescription = document.getElementById('modalDescription');
+        const modalSpecs = document.getElementById('modalSpecs');
+
+        const catalogState = {
+            categories: [],
+            productMap: new Map(),
+            activeCategory: null
         };
 
-        // Ocultar loader cuando la página carga
+        const observerOptions = {
+            threshold: 0.1,
+            rootMargin: '0px 0px -50px 0px'
+        };
+
+        const productObserver = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.style.animation = 'fadeInUp 0.6s ease-out forwards';
+                    productObserver.unobserve(entry.target);
+                }
+            });
+        }, observerOptions);
+
+        function observeCard(card) {
+            card.style.opacity = '0';
+            productObserver.observe(card);
+        }
+
         window.addEventListener('load', function() {
             setTimeout(() => {
-                document.getElementById('loader').classList.add('hidden');
+                const loader = document.getElementById('loader');
+                if (loader) {
+                    loader.classList.add('hidden');
+                }
             }, 1500);
         });
 
-        // Función para mostrar categorías
-        function showCategory(categoryId, button) {
-            // Ocultar todas las categorías
-            const categories = document.querySelectorAll('.category');
-            categories.forEach(cat => cat.classList.remove('active'));
-
-            // Mostrar la categoría seleccionada
-            document.getElementById(categoryId).classList.add('active');
-
-            // Actualizar botones de navegación
-            const buttons = document.querySelectorAll('.nav-btn');
-            buttons.forEach(btn => btn.classList.remove('active'));
-            if (button) {
-                button.classList.add('active');
+        function formatPrice(value) {
+            const number = Number(value);
+            if (Number.isNaN(number)) {
+                return '';
             }
-            
-            // Scroll suave al inicio del contenido
-            window.scrollTo({
-                top: document.querySelector('.nav-container').offsetTop - 20,
-                behavior: 'smooth'
+            try {
+                return new Intl.NumberFormat('es-CO', {
+                    style: 'currency',
+                    currency: 'COP',
+                    maximumFractionDigits: 0
+                }).format(number);
+            } catch (error) {
+                return `$${number.toFixed(0)}`;
+            }
+        }
+
+        function renderNavigation() {
+            navButtonsContainer.innerHTML = '';
+            catalogState.categories.forEach((category, index) => {
+                const button = document.createElement('button');
+                button.className = 'nav-btn';
+                button.dataset.category = category.slug;
+                const icon = (category.products[0] && category.products[0].icon) || '📦';
+                button.textContent = `${icon} ${category.name}`;
+                button.addEventListener('click', () => showCategory(category.slug, button));
+                if (index === 0) {
+                    button.classList.add('active');
+                }
+                navButtonsContainer.appendChild(button);
             });
         }
 
-        // Función para abrir modal
-        function openModal(productId) {
-            const modal = document.getElementById('productModal');
-            const product = productData[productId];
-            
-            if (product) {
-                currentProduct = product.title;
-                document.getElementById('modalTitle').textContent = product.title;
-                document.getElementById('modalImage').textContent = product.icon;
-                document.getElementById('modalDescription').textContent = product.description;
-                
-                // Actualizar especificaciones
-                const specsList = document.getElementById('modalSpecs');
-                specsList.innerHTML = product.specs.map(spec => 
-                    `<li><span>${spec[0]}:</span><span>${spec[1]}</span></li>`
-                ).join('');
+        function createProductCard(product) {
+            const card = document.createElement('div');
+            card.className = 'product-card';
+            card.dataset.productId = product.slug;
+            card.addEventListener('click', () => openModal(product.slug));
+
+            const image = document.createElement('div');
+            image.className = 'product-image';
+            image.textContent = product.icon || '🏷️';
+            card.appendChild(image);
+
+            const info = document.createElement('div');
+            info.className = 'product-info';
+
+            const nameEl = document.createElement('h3');
+            nameEl.className = 'product-name';
+            nameEl.textContent = product.name;
+            info.appendChild(nameEl);
+
+            const descriptionEl = document.createElement('p');
+            descriptionEl.className = 'product-description';
+            descriptionEl.textContent = product.description || 'Descubre más detalles en el catálogo.';
+            info.appendChild(descriptionEl);
+
+            if (Array.isArray(product.specs) && product.specs.length > 0) {
+                const features = document.createElement('div');
+                features.className = 'product-features';
+                product.specs.slice(0, 2).forEach(spec => {
+                    const tag = document.createElement('span');
+                    tag.className = 'feature-tag';
+                    tag.textContent = spec[1];
+                    features.appendChild(tag);
+                });
+                info.appendChild(features);
             }
-            
-            modal.classList.add('active');
+
+            if (product.price !== null && product.price !== undefined) {
+                const priceEl = document.createElement('p');
+                priceEl.className = 'product-price';
+                priceEl.textContent = formatPrice(product.price);
+                info.appendChild(priceEl);
+            }
+
+            card.appendChild(info);
+            observeCard(card);
+            return card;
+        }
+
+        function renderCategories() {
+            catalogContainer.innerHTML = '';
+
+            catalogState.categories.forEach((category, index) => {
+                const section = document.createElement('div');
+                section.className = 'category';
+                section.id = category.slug;
+                if (index === 0) {
+                    section.classList.add('active');
+                }
+
+                const title = document.createElement('h2');
+                title.className = 'category-title';
+                title.textContent = category.name;
+                section.appendChild(title);
+
+                const description = document.createElement('p');
+                description.className = 'category-description';
+                description.textContent = category.description || 'Explora nuestra selección de productos.';
+                section.appendChild(description);
+
+                const grid = document.createElement('div');
+                grid.className = 'products-grid';
+
+                if (!category.products.length) {
+                    const empty = document.createElement('p');
+                    empty.className = 'subtitle';
+                    empty.textContent = 'No hay productos disponibles en esta categoría.';
+                    grid.appendChild(empty);
+                } else {
+                    category.products.forEach(product => {
+                        const card = createProductCard(product);
+                        grid.appendChild(card);
+                    });
+                }
+
+                section.appendChild(grid);
+                catalogContainer.appendChild(section);
+            });
+        }
+
+        function showCategory(categorySlug, button) {
+            catalogState.activeCategory = categorySlug;
+            document.querySelectorAll('.category').forEach(section => {
+                section.classList.toggle('active', section.id === categorySlug);
+            });
+
+            document.querySelectorAll('.nav-btn').forEach(btn => {
+                const isActive = btn === button || btn.dataset.category === categorySlug;
+                btn.classList.toggle('active', isActive);
+            });
+
+            const nav = document.querySelector('.nav-container');
+            if (nav) {
+                window.scrollTo({
+                    top: nav.offsetTop - 20,
+                    behavior: 'smooth'
+                });
+            }
+        }
+
+        function openModal(productSlug) {
+            const product = catalogState.productMap.get(productSlug);
+            if (!product) {
+                return;
+            }
+
+            currentProduct = product.name;
+            modalTitle.textContent = product.name;
+            modalImage.textContent = product.icon || '🏷️';
+            modalDescription.textContent = product.description || 'Contáctanos para más detalles de este producto.';
+
+            modalSpecs.innerHTML = '';
+            if (Array.isArray(product.specs) && product.specs.length > 0) {
+                product.specs.forEach(([label, value]) => {
+                    const item = document.createElement('li');
+                    const labelSpan = document.createElement('span');
+                    labelSpan.textContent = `${label}:`;
+                    const valueSpan = document.createElement('span');
+                    valueSpan.textContent = value;
+                    item.appendChild(labelSpan);
+                    item.appendChild(valueSpan);
+                    modalSpecs.appendChild(item);
+                });
+            } else {
+                const item = document.createElement('li');
+                item.textContent = 'Sin especificaciones adicionales.';
+                modalSpecs.appendChild(item);
+            }
+
+            productModal.classList.add('active');
             document.body.style.overflow = 'hidden';
         }
 
-        // Función para cerrar modal
         function closeModal() {
-            const modal = document.getElementById('productModal');
-            modal.classList.remove('active');
+            productModal.classList.remove('active');
             document.body.style.overflow = 'auto';
         }
 
-        // Cerrar modal al hacer clic fuera
         document.getElementById('productModal').addEventListener('click', function(e) {
             if (e.target === this) {
                 closeModal();
             }
         });
 
-        // Función para contactar por WhatsApp
         function contactWhatsApp() {
-            const message = `Hola! Me interesa el producto: ${currentProduct}. ¿Podrían darme más información?`;
-            const phone = '573000000000'; // Reemplazar con tu número
+            const productName = currentProduct || 'uno de sus productos';
+            const message = `Hola! Me interesa el producto: ${productName}. ¿Podrían darme más información?`;
+            const phone = '573000000000';
             const url = `https://wa.me/${phone}?text=${encodeURIComponent(message)}`;
             window.open(url, '_blank');
         }
 
-        // Función para solicitar cotización
         function requestQuote() {
-            const subject = `Cotización - ${currentProduct}`;
-            const body = `Hola,\n\nMe gustaría recibir una cotización para el producto: ${currentProduct}.\n\nMis datos de contacto son:\nNombre:\nTeléfono:\nCantidad requerida:\n\nGracias!`;
-            const email = 'info@amazoniaconcrete.com'; // Reemplazar con tu email
+            const productName = currentProduct || 'producto del catálogo';
+            const subject = `Cotización - ${productName}`;
+            const body = `Hola,
+
+Me gustaría recibir una cotización para el producto: ${productName}.
+
+Mis datos de contacto son: 
+Nombre: 
+Teléfono: 
+Cantidad requerida: 
+
+Gracias!`;
+            const email = 'info@amazoniaconcrete.com';
             const url = `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
             window.location.href = url;
         }
 
-        // Animación de entrada para las tarjetas de producto
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
-        };
-
-        const observer = new IntersectionObserver(function(entries) {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.style.animation = 'fadeInUp 0.6s ease-out forwards';
-                    observer.unobserve(entry.target);
-                }
-            });
-        }, observerOptions);
-
-        // Observar todas las tarjetas de producto
-        document.addEventListener('DOMContentLoaded', function() {
-            const cards = document.querySelectorAll('.product-card');
-            cards.forEach(card => {
-                card.style.opacity = '0';
-                observer.observe(card);
-            });
-        });
-
-        // Efecto parallax suave en el header
         window.addEventListener('scroll', function() {
             const scrolled = window.pageYOffset;
             const header = document.querySelector('header');
-            if (scrolled < 300) {
+            if (header && scrolled < 300) {
                 header.style.transform = `translateY(${scrolled * 0.5}px)`;
             }
+        });
+
+        async function loadCatalog() {
+            catalogContainer.innerHTML = '<p class="loading-message">Cargando catálogo...</p>';
+            try {
+                const response = await fetch('/api/catalog');
+                if (!response.ok) {
+                    throw new Error('No se pudo obtener el catálogo.');
+                }
+                const data = await response.json();
+                catalogState.categories = (data.categories || []).map(category => ({
+                    ...category,
+                    products: (category.products || []).map(product => ({
+                        ...product,
+                        specs: Array.isArray(product.specs) ? product.specs : [],
+                        price: product.price !== null && product.price !== undefined ? Number(product.price) : null,
+                        icon: product.icon || ''
+                    }))
+                }));
+
+                catalogState.productMap = new Map();
+                catalogState.categories.forEach(category => {
+                    (category.products || []).forEach(product => {
+                        catalogState.productMap.set(product.slug, {
+                            ...product,
+                            categoryName: category.name
+                        });
+                    });
+                });
+
+                if (!catalogState.categories.length) {
+                    navButtonsContainer.innerHTML = '<p class="nav-placeholder">No hay categorías disponibles.</p>';
+                    catalogContainer.innerHTML = '<p class="error-message">No hay productos disponibles por el momento.</p>';
+                    return;
+                }
+
+                renderNavigation();
+                renderCategories();
+                showCategory(catalogState.categories[0].slug);
+            } catch (error) {
+                console.error('Error al cargar el catálogo:', error);
+                navButtonsContainer.innerHTML = '<p class="nav-placeholder">No se pudo cargar el catálogo.</p>';
+                catalogContainer.innerHTML = `<p class="error-message">${error.message}</p>`;
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            loadCatalog();
         });
     </script>
 </body>

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const dataDir = path.join(__dirname, '..', 'data');
+fs.mkdirSync(dataDir, { recursive: true });
+
+const dbPath = path.join(dataDir, 'catalog.db');
+const db = new Database(dbPath);
+db.pragma('foreign_keys = ON');
+
+db.pragma('journal_mode = WAL');
+
+module.exports = db;

--- a/server/db/migrate.js
+++ b/server/db/migrate.js
@@ -1,0 +1,267 @@
+const path = require('path');
+const bcrypt = require('bcrypt');
+const db = require('./index');
+
+function loadEnv() {
+  const dotenvPath = path.join(__dirname, '..', '.env');
+  require('dotenv').config({ path: dotenvPath });
+}
+
+function runMigrations() {
+  loadEnv();
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS categories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      slug TEXT NOT NULL UNIQUE,
+      description TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS products (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      category_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      slug TEXT NOT NULL UNIQUE,
+      icon TEXT,
+      description TEXT,
+      specs TEXT,
+      price REAL,
+      image_url TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+    );
+  `);
+
+  const now = new Date().toISOString();
+  const defaultUsername = process.env.ADMIN_USER || 'admin';
+  const defaultPassword = process.env.ADMIN_PASSWORD || 'admin123';
+
+  const existingUser = db.prepare('SELECT id FROM users WHERE username = ?').get(defaultUsername);
+  if (!existingUser) {
+    const passwordHash = bcrypt.hashSync(defaultPassword, 10);
+    db.prepare(`
+      INSERT INTO users (username, password_hash, created_at, updated_at)
+      VALUES (?, ?, ?, ?)
+    `).run(defaultUsername, passwordHash, now, now);
+  }
+
+  const categories = [
+    { slug: 'macetas', name: 'Macetas', description: 'Colección de macetas inspiradas en la Amazonía.' },
+    { slug: 'pisos', name: 'Pisos', description: 'Pisos de concreto de alto rendimiento.' },
+    { slug: 'revestimientos', name: 'Revestimientos', description: 'Revestimientos decorativos y funcionales.' }
+  ];
+
+  const insertCategory = db.prepare(`
+    INSERT INTO categories (name, slug, description, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(slug) DO UPDATE SET
+      name = excluded.name,
+      description = excluded.description,
+      updated_at = excluded.updated_at;
+  `);
+
+  categories.forEach((category) => {
+    insertCategory.run(
+      category.name,
+      category.slug,
+      category.description,
+      now,
+      now
+    );
+  });
+
+  const categoryIds = Object.fromEntries(
+    db
+      .prepare('SELECT id, slug FROM categories WHERE slug IN (?, ?, ?)')
+      .all('macetas', 'pisos', 'revestimientos')
+      .map((row) => [row.slug, row.id])
+  );
+
+  const products = [
+    {
+      category: 'macetas',
+      slug: 'maceta-tropical',
+      name: 'Maceta Tropical',
+      icon: '🪴',
+      description:
+        'Maceta con textura inspirada en la selva amazónica. Incluye sistema de drenaje integrado.',
+      specs: [
+        ['Material', 'Concreto reforzado con fibra'],
+        ['Dimensiones', '30cm x 25cm x 28cm'],
+        ['Peso', '8 kg'],
+        ['Colores', 'Gris natural, Verde musgo, Terracota'],
+        ['Drenaje', 'Sistema integrado con plato'],
+        ['Garantía', '2 años']
+      ]
+    },
+    {
+      category: 'macetas',
+      slug: 'maceta-minimalista',
+      name: 'Maceta Minimalista',
+      icon: '🌿',
+      description:
+        'Diseño contemporáneo con acabado liso y formas geométricas. Ideal para suculentas y cactus.',
+      specs: [
+        ['Material', 'Concreto pulido'],
+        ['Dimensiones', '20cm x 20cm x 18cm'],
+        ['Peso', '4 kg'],
+        ['Colores', 'Blanco, Gris, Negro'],
+        ['Acabado', 'Sellador impermeable'],
+        ['Garantía', '2 años']
+      ]
+    },
+    {
+      category: 'macetas',
+      slug: 'jardin-vertical',
+      name: 'Set Jardín Vertical',
+      icon: '🌱',
+      description:
+        'Sistema modular para crear jardines verticales con riego por goteo opcional.',
+      specs: [
+        ['Material', 'Concreto aligerado'],
+        ['Módulos', '3 piezas hexagonales'],
+        ['Dimensiones', '25cm x 22cm cada módulo'],
+        ['Peso total', '12 kg'],
+        ['Instalación', 'Incluye kit de montaje'],
+        ['Garantía', '3 años']
+      ]
+    },
+    {
+      category: 'pisos',
+      slug: 'baldosa-amazonia',
+      name: 'Baldosa Amazonia',
+      icon: '⬜',
+      description:
+        'Baldosas premium con relieve de hojas y acabado antideslizante para exteriores.',
+      specs: [
+        ['Material', 'Concreto de alta resistencia'],
+        ['Dimensiones', '40cm x 40cm x 4cm'],
+        ['Peso', '12 kg/unidad'],
+        ['Resistencia', '350 kg/cm²'],
+        ['Acabado', 'Antideslizante clase 3'],
+        ['Vida útil', '25+ años']
+      ]
+    },
+    {
+      category: 'pisos',
+      slug: 'concreto-pulido',
+      name: 'Concreto Pulido',
+      icon: '⬛',
+      description:
+        'Piso con acabado espejo obtenido mediante pulido diamantado y sellador de última generación.',
+      specs: [
+        ['Espesor', '10-15cm'],
+        ['Acabado', 'Pulido diamantado 3000 grit'],
+        ['Sellador', 'Base agua, bajo VOC'],
+        ['Mantenimiento', 'Mínimo'],
+        ['Colores', 'Personalizable con tintes'],
+        ['Garantía', '10 años']
+      ]
+    },
+    {
+      category: 'pisos',
+      slug: 'adoquin-ecologico',
+      name: 'Adoquín Ecológico',
+      icon: '🔲',
+      description:
+        'Adoquines permeables que permiten la filtración natural del agua, ideales para proyectos sostenibles.',
+      specs: [
+        ['Material', 'Concreto poroso'],
+        ['Dimensiones', '20cm x 10cm x 8cm'],
+        ['Permeabilidad', '300 l/m²/min'],
+        ['Peso', '3.5 kg/unidad'],
+        ['Resistencia', '280 kg/cm²'],
+        ['Certificación', 'Compatible con LEED']
+      ]
+    },
+    {
+      category: 'revestimientos',
+      slug: 'panel-3d-selva',
+      name: 'Panel 3D Selva',
+      icon: '🏗️',
+      description:
+        'Paneles decorativos con relieve tridimensional que recrea la exuberancia de la selva amazónica.',
+      specs: [
+        ['Material', 'Concreto arquitectónico'],
+        ['Dimensiones', '60cm x 60cm x 3cm'],
+        ['Peso', '15 kg/panel'],
+        ['Instalación', 'Adhesivo especial incluido'],
+        ['Acabado', 'Pintura mineral ecológica'],
+        ['Uso', 'Interior']
+      ]
+    },
+    {
+      category: 'revestimientos',
+      slug: 'ladrillo-aparente',
+      name: 'Ladrillo Aparente',
+      icon: '🧱',
+      description:
+        'Revestimiento que simula ladrillo expuesto con durabilidad del concreto y múltiples tonos.',
+      specs: [
+        ['Material', 'Concreto texturizado'],
+        ['Formato', 'Placas de 50x25cm'],
+        ['Espesor', '2cm'],
+        ['Colores', 'Rojo, Café, Gris, Blanco'],
+        ['Instalación', 'Sistema click o adhesivo'],
+        ['Rendimiento', '8 placas/m²']
+      ]
+    }
+  ];
+
+  const insertProduct = db.prepare(`
+    INSERT INTO products (
+      category_id,
+      name,
+      slug,
+      icon,
+      description,
+      specs,
+      price,
+      image_url,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(slug) DO UPDATE SET
+      category_id = excluded.category_id,
+      name = excluded.name,
+      icon = excluded.icon,
+      description = excluded.description,
+      specs = excluded.specs,
+      price = excluded.price,
+      image_url = excluded.image_url,
+      updated_at = excluded.updated_at;
+  `);
+
+  products.forEach((product) => {
+    const categoryId = categoryIds[product.category];
+    if (!categoryId) {
+      return;
+    }
+    insertProduct.run(
+      categoryId,
+      product.name,
+      product.slug,
+      product.icon,
+      product.description,
+      JSON.stringify(product.specs),
+      null,
+      null,
+      now,
+      now
+    );
+  });
+}
+
+module.exports = { runMigrations };

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,138 @@
+const path = require('path');
+const express = require('express');
+const session = require('express-session');
+const cors = require('cors');
+const csurf = require('csurf');
+const dotenv = require('dotenv');
+
+const db = require('./db');
+const { runMigrations } = require('./db/migrate');
+const authRouter = require('./routes/auth');
+const categoriesRouter = require('./routes/categories');
+const productsRouter = require('./routes/products');
+
+const rootDir = path.join(__dirname, '..');
+dotenv.config({ path: path.join(rootDir, '.env') });
+dotenv.config();
+
+runMigrations();
+
+const app = express();
+app.set('trust proxy', 1);
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const corsOptions = {
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
+};
+
+if (allowedOrigins.length > 0) {
+  corsOptions.origin = (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Origen no permitido por CORS'));
+  };
+} else {
+  corsOptions.origin = true;
+}
+
+app.use(cors(corsOptions));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'catalogo-amazonia-dev-secret',
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production'
+    }
+  })
+);
+
+const csrfProtection = csurf();
+
+app.use('/api', (req, res, next) => {
+  if (req.path === '/catalog') {
+    return next();
+  }
+  return csrfProtection(req, res, next);
+});
+
+app.use('/api/auth', authRouter);
+app.use('/api/categories', categoriesRouter);
+app.use('/api/products', productsRouter);
+
+app.get('/api/catalog', (req, res) => {
+  const categories = db
+    .prepare('SELECT id, name, slug, description, created_at AS createdAt, updated_at AS updatedAt FROM categories ORDER BY name ASC')
+    .all();
+
+  const products = db
+    .prepare(
+      'SELECT id, category_id AS categoryId, name, slug, icon, description, specs, price, image_url AS imageUrl, created_at AS createdAt, updated_at AS updatedAt FROM products'
+    )
+    .all();
+
+  const catalog = categories.map((category) => ({
+    ...category,
+    products: products
+      .filter((product) => product.categoryId === category.id)
+      .map((product) => ({
+        ...product,
+        specs: product.specs ? JSON.parse(product.specs) : []
+      }))
+  }));
+
+  return res.json({ categories: catalog });
+});
+
+app.use('/admin', express.static(path.join(rootDir, 'admin')));
+
+app.use((req, res, next) => {
+  if (req.method !== 'GET') {
+    return next();
+  }
+
+  if (req.path.startsWith('/api')) {
+    return next();
+  }
+
+  if (req.path.startsWith('/admin')) {
+    return res.sendFile(path.join(rootDir, 'admin', 'index.html'));
+  }
+
+  if (req.path === '/' || req.path === '/index.html') {
+    return res.sendFile(path.join(rootDir, 'index.html'));
+  }
+
+  return res.sendFile(path.join(rootDir, 'index.html'));
+});
+
+app.use((err, req, res, next) => {
+  if (err.code === 'EBADCSRFTOKEN') {
+    return res.status(403).json({ error: 'Token CSRF inválido o ausente.' });
+  }
+  return next(err);
+});
+
+app.use((err, req, res, next) => {
+  console.error('Error inesperado:', err);
+  if (res.headersSent) {
+    return next(err);
+  }
+  return res.status(500).json({ error: 'Error interno del servidor.' });
+});
+
+const PORT = Number.parseInt(process.env.PORT || '3000', 10);
+app.listen(PORT, () => {
+  console.log(`Servidor escuchando en http://localhost:${PORT}`);
+});

--- a/server/middleware/requireAuth.js
+++ b/server/middleware/requireAuth.js
@@ -1,0 +1,8 @@
+function requireAuth(req, res, next) {
+  if (req.session && req.session.userId) {
+    return next();
+  }
+  return res.status(401).json({ error: 'Autenticación requerida' });
+}
+
+module.exports = requireAuth;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,1972 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "server",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "bcrypt": "^6.0.0",
+        "better-sqlite3": "^12.2.0",
+        "cors": "^2.8.5",
+        "csurf": "^1.11.0",
+        "dotenv": "^17.2.2",
+        "express": "^5.1.0",
+        "express-session": "^1.18.2"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.10"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "license": "MIT",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/express/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
+      "license": "MIT"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "nodemon index.js",
+    "start": "node index.js",
+    "migrate": "node scripts/migrate.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcrypt": "^6.0.0",
+    "better-sqlite3": "^12.2.0",
+    "cors": "^2.8.5",
+    "csurf": "^1.11.0",
+    "dotenv": "^17.2.2",
+    "express": "^5.1.0",
+    "express-session": "^1.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10"
+  }
+}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const db = require('../db');
+const requireAuth = require('../middleware/requireAuth');
+
+const router = express.Router();
+
+router.get('/csrf', (req, res) => {
+  return res.json({ csrfToken: req.csrfToken() });
+});
+
+router.get('/session', (req, res) => {
+  if (req.session && req.session.userId) {
+    return res.json({
+      authenticated: true,
+      user: {
+        id: req.session.userId,
+        username: req.session.username
+      }
+    });
+  }
+
+  return res.json({ authenticated: false });
+});
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body || {};
+
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Usuario y contraseña son requeridos.' });
+  }
+
+  const user = db
+    .prepare('SELECT id, username, password_hash FROM users WHERE username = ?')
+    .get(username);
+
+  if (!user) {
+    return res.status(401).json({ error: 'Credenciales inválidas.' });
+  }
+
+  const match = await bcrypt.compare(password, user.password_hash);
+  if (!match) {
+    return res.status(401).json({ error: 'Credenciales inválidas.' });
+  }
+
+  req.session.userId = user.id;
+  req.session.username = user.username;
+
+  return res.json({
+    message: 'Autenticación exitosa.',
+    user: { id: user.id, username: user.username },
+    csrfToken: req.csrfToken()
+  });
+});
+
+router.post('/logout', requireAuth, (req, res) => {
+  req.session.destroy((err) => {
+    if (err) {
+      return res.status(500).json({ error: 'No se pudo cerrar la sesión.' });
+    }
+    res.clearCookie('connect.sid');
+    return res.json({ message: 'Sesión finalizada.' });
+  });
+});
+
+module.exports = router;

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -1,0 +1,121 @@
+const express = require('express');
+const db = require('../db');
+const requireAuth = require('../middleware/requireAuth');
+
+const router = express.Router();
+
+const slugify = (value) =>
+  value
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+    .substring(0, 60);
+
+router.use(requireAuth);
+
+router.get('/', (req, res) => {
+  const categories = db
+    .prepare('SELECT id, name, slug, description, created_at, updated_at FROM categories ORDER BY name ASC')
+    .all();
+
+  return res.json({ categories });
+});
+
+router.post('/', (req, res) => {
+  const { name, description, slug } = req.body || {};
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'El nombre de la categoría es obligatorio.' });
+  }
+
+  const normalizedName = name.trim();
+  const now = new Date().toISOString();
+  const generatedSlug = (slug && slug.trim()) || slugify(normalizedName);
+
+  try {
+    const result = db.prepare(`
+      INSERT INTO categories (name, slug, description, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(normalizedName, generatedSlug, description || null, now, now);
+
+    const category = db
+      .prepare('SELECT id, name, slug, description, created_at, updated_at FROM categories WHERE id = ?')
+      .get(result.lastInsertRowid);
+
+    return res.status(201).json({ category });
+  } catch (error) {
+    if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      return res.status(409).json({ error: 'Ya existe una categoría con ese slug.' });
+    }
+    console.error('Error al crear categoría:', error);
+    return res.status(500).json({ error: 'No se pudo crear la categoría.' });
+  }
+});
+
+router.put('/:id', (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ error: 'Identificador inválido.' });
+  }
+
+  const existing = db
+    .prepare('SELECT id FROM categories WHERE id = ?')
+    .get(id);
+
+  if (!existing) {
+    return res.status(404).json({ error: 'Categoría no encontrada.' });
+  }
+
+  const { name, description, slug } = req.body || {};
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'El nombre de la categoría es obligatorio.' });
+  }
+
+  const normalizedName = name.trim();
+  const now = new Date().toISOString();
+  const generatedSlug = (slug && slug.trim()) || slugify(normalizedName);
+
+  try {
+    db.prepare(`
+      UPDATE categories
+      SET name = ?, slug = ?, description = ?, updated_at = ?
+      WHERE id = ?
+    `).run(normalizedName, generatedSlug, description || null, now, id);
+
+    const category = db
+      .prepare('SELECT id, name, slug, description, created_at, updated_at FROM categories WHERE id = ?')
+      .get(id);
+
+    return res.json({ category });
+  } catch (error) {
+    if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      return res.status(409).json({ error: 'Ya existe una categoría con ese slug.' });
+    }
+    console.error('Error al actualizar categoría:', error);
+    return res.status(500).json({ error: 'No se pudo actualizar la categoría.' });
+  }
+});
+
+router.delete('/:id', (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ error: 'Identificador inválido.' });
+  }
+
+  const existing = db
+    .prepare('SELECT id FROM categories WHERE id = ?')
+    .get(id);
+
+  if (!existing) {
+    return res.status(404).json({ error: 'Categoría no encontrada.' });
+  }
+
+  db.prepare('DELETE FROM categories WHERE id = ?').run(id);
+
+  return res.status(204).send();
+});
+
+module.exports = router;

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -1,0 +1,255 @@
+const express = require('express');
+const db = require('../db');
+const requireAuth = require('../middleware/requireAuth');
+
+const router = express.Router();
+
+const slugify = (value) =>
+  value
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+    .substring(0, 80);
+
+const normalizeSpecs = (specs) => {
+  if (!specs) {
+    return [];
+  }
+
+  if (Array.isArray(specs)) {
+    return specs
+      .map((entry) => {
+        if (Array.isArray(entry) && entry.length >= 2) {
+          return [String(entry[0]).trim(), String(entry[1]).trim()];
+        }
+        return null;
+      })
+      .filter(Boolean);
+  }
+
+  if (typeof specs === 'string') {
+    return specs
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [label, ...valueParts] = line.split(':');
+        if (!label || valueParts.length === 0) {
+          return null;
+        }
+        return [label.trim(), valueParts.join(':').trim()];
+      })
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+router.use(requireAuth);
+
+router.get('/', (req, res) => {
+  const { categoryId } = req.query;
+  let query = `
+    SELECT id, category_id AS categoryId, name, slug, icon, description, specs, price, image_url AS imageUrl,
+           created_at AS createdAt, updated_at AS updatedAt
+    FROM products
+  `;
+  const params = [];
+
+  if (categoryId !== undefined) {
+    const parsedCategoryId = Number.parseInt(categoryId, 10);
+    if (Number.isNaN(parsedCategoryId)) {
+      return res.status(400).json({ error: 'El identificador de categoría no es válido.' });
+    }
+    query += ' WHERE category_id = ?';
+    params.push(parsedCategoryId);
+  }
+
+  query += ' ORDER BY name ASC';
+
+  const products = db.prepare(query).all(...params).map((product) => ({
+    ...product,
+    specs: product.specs ? JSON.parse(product.specs) : []
+  }));
+
+  return res.json({ products });
+});
+
+router.post('/', (req, res) => {
+  const { name, description, slug, icon, specs, price, imageUrl, categoryId } = req.body || {};
+
+  const numericCategoryId = Number.parseInt(categoryId, 10);
+  if (Number.isNaN(numericCategoryId)) {
+    return res.status(400).json({ error: 'La categoría es obligatoria.' });
+  }
+
+  const category = db.prepare('SELECT id FROM categories WHERE id = ?').get(numericCategoryId);
+  if (!category) {
+    return res.status(400).json({ error: 'La categoría seleccionada no existe.' });
+  }
+
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'El nombre del producto es obligatorio.' });
+  }
+
+  const normalizedName = name.trim();
+  const normalizedSlug = (slug && slug.trim()) || slugify(normalizedName);
+  const normalizedSpecs = normalizeSpecs(specs);
+  const now = new Date().toISOString();
+
+  let normalizedPrice = null;
+  if (price !== undefined && price !== null && String(price).trim() !== '') {
+    const parsed = Number.parseFloat(price);
+    if (Number.isNaN(parsed)) {
+      return res.status(400).json({ error: 'El precio debe ser un número válido.' });
+    }
+    normalizedPrice = parsed;
+  }
+
+  try {
+    const result = db.prepare(`
+      INSERT INTO products (category_id, name, slug, icon, description, specs, price, image_url, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      numericCategoryId,
+      normalizedName,
+      normalizedSlug,
+      icon || null,
+      description || null,
+      JSON.stringify(normalizedSpecs),
+      normalizedPrice,
+      imageUrl || null,
+      now,
+      now
+    );
+
+    const product = db
+      .prepare(
+        `SELECT id, category_id AS categoryId, name, slug, icon, description, specs, price, image_url AS imageUrl,
+                created_at AS createdAt, updated_at AS updatedAt FROM products WHERE id = ?`
+      )
+      .get(result.lastInsertRowid);
+
+    return res.status(201).json({
+      product: {
+        ...product,
+        specs: product.specs ? JSON.parse(product.specs) : []
+      }
+    });
+  } catch (error) {
+    if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      return res.status(409).json({ error: 'Ya existe un producto con ese slug.' });
+    }
+    console.error('Error al crear producto:', error);
+    return res.status(500).json({ error: 'No se pudo crear el producto.' });
+  }
+});
+
+router.put('/:id', (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ error: 'Identificador inválido.' });
+  }
+
+  const existing = db
+    .prepare('SELECT id FROM products WHERE id = ?')
+    .get(id);
+
+  if (!existing) {
+    return res.status(404).json({ error: 'Producto no encontrado.' });
+  }
+
+  const { name, description, slug, icon, specs, price, imageUrl, categoryId } = req.body || {};
+
+  const numericCategoryId = Number.parseInt(categoryId, 10);
+  if (Number.isNaN(numericCategoryId)) {
+    return res.status(400).json({ error: 'La categoría es obligatoria.' });
+  }
+
+  const category = db.prepare('SELECT id FROM categories WHERE id = ?').get(numericCategoryId);
+  if (!category) {
+    return res.status(400).json({ error: 'La categoría seleccionada no existe.' });
+  }
+
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'El nombre del producto es obligatorio.' });
+  }
+
+  const normalizedName = name.trim();
+  const normalizedSlug = (slug && slug.trim()) || slugify(normalizedName);
+  const normalizedSpecs = normalizeSpecs(specs);
+  const now = new Date().toISOString();
+
+  let normalizedPrice = null;
+  if (price !== undefined && price !== null && String(price).trim() !== '') {
+    const parsed = Number.parseFloat(price);
+    if (Number.isNaN(parsed)) {
+      return res.status(400).json({ error: 'El precio debe ser un número válido.' });
+    }
+    normalizedPrice = parsed;
+  }
+
+  try {
+    db.prepare(`
+      UPDATE products
+      SET category_id = ?, name = ?, slug = ?, icon = ?, description = ?, specs = ?, price = ?, image_url = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      numericCategoryId,
+      normalizedName,
+      normalizedSlug,
+      icon || null,
+      description || null,
+      JSON.stringify(normalizedSpecs),
+      normalizedPrice,
+      imageUrl || null,
+      now,
+      id
+    );
+
+    const product = db
+      .prepare(
+        `SELECT id, category_id AS categoryId, name, slug, icon, description, specs, price, image_url AS imageUrl,
+                created_at AS createdAt, updated_at AS updatedAt FROM products WHERE id = ?`
+      )
+      .get(id);
+
+    return res.json({
+      product: {
+        ...product,
+        specs: product.specs ? JSON.parse(product.specs) : []
+      }
+    });
+  } catch (error) {
+    if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      return res.status(409).json({ error: 'Ya existe un producto con ese slug.' });
+    }
+    console.error('Error al actualizar producto:', error);
+    return res.status(500).json({ error: 'No se pudo actualizar el producto.' });
+  }
+});
+
+router.delete('/:id', (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ error: 'Identificador inválido.' });
+  }
+
+  const existing = db
+    .prepare('SELECT id FROM products WHERE id = ?')
+    .get(id);
+
+  if (!existing) {
+    return res.status(404).json({ error: 'Producto no encontrado.' });
+  }
+
+  db.prepare('DELETE FROM products WHERE id = ?').run(id);
+
+  return res.status(204).send();
+});
+
+module.exports = router;

--- a/server/scripts/migrate.js
+++ b/server/scripts/migrate.js
@@ -1,0 +1,4 @@
+const { runMigrations } = require('../db/migrate');
+
+runMigrations();
+console.log('Database migrated and seeded successfully.');


### PR DESCRIPTION
## Summary
- add an Express-based backend with SQLite persistence, REST endpoints, session auth, and CSRF protection
- create an admin SPA to manage categories and products through the new API
- update the public catalog to load data from the API and document the workflow in README

## Testing
- npm run migrate
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cdca7e9fa883329ba2b63397cefc95