### PR TITLE
Escape closing script tag in generated catalog

### DIFF
--- a/amazonia_admin_complete.html
+++ b/amazonia_admin_complete.html
@@ -1086,7 +1086,7 @@
 
     <script>
         ${getCatalogScript(productDataJS, config)}
-    </script>
+    <\/script>
 </body>
 </html>`;
         }


### PR DESCRIPTION
## Summary
- escape the closing script tag in the generated catalog template so the admin page script stays intact

## Testing
- manual Playwright check of amazonia_admin_complete.html

------
https://chatgpt.com/codex/tasks/task_e_68cf004993848332a33372017d705f88