### PR TITLE
Ensure catalog observer exists before DOM ready handler

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2002,6 +2002,20 @@
         const productData = ${JSON.stringify(productData)};
         const catalogConfig = ${JSON.stringify(config || {})};
 
+        const observerOptions = {
+            threshold: 0.1,
+            rootMargin: '0px 0px -50px 0px'
+        };
+
+        const observer = new IntersectionObserver(function(entries) {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.style.animation = 'fadeInUp 0.6s ease-out forwards';
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, observerOptions);
+
         window.addEventListener('load', function() {
             setTimeout(() => {
                 const loader = document.getElementById('loader');
@@ -2237,20 +2251,6 @@
             const url = \`mailto:\${emailValue}?subject=\${encodeURIComponent(subject)}&body=\${encodeURIComponent(body)}\`;
             window.location.href = url;
         }
-
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
-        };
-
-        const observer = new IntersectionObserver(function(entries) {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.style.animation = 'fadeInUp 0.6s ease-out forwards';
-                    observer.unobserve(entry.target);
-                }
-            });
-        }, observerOptions);
 
         window.addEventListener('scroll', function() {
             const scrolled = window.pageYOffset;


### PR DESCRIPTION
## Summary
- move the IntersectionObserver setup inside the catalog preview script before the DOMContentLoaded handler so it exists when used

## Testing
- Manually opened admin.html in a browser, clicked "Actualizar vista previa" and confirmed no console ReferenceError while preview updated

------
https://chatgpt.com/codex/tasks/task_e_68d0685a4518833282aa31f5c17c2610