### PR TITLE
Escape inner template literal in admin modal alt text

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2318,7 +2318,7 @@
 
             if (imageEl) {
                 imageEl.src = product.image || '';
-                imageEl.alt = product.alt || `Imagen de ${product.title}`;
+                imageEl.alt = product.alt || \`Imagen de \${product.title}\`;
             }
 
             if (descriptionEl) {


### PR DESCRIPTION
## Summary
- escape the backticks and interpolation sequence in the modal image alt text assignment inside `getCatalogScript`
- ensure the generated script retains the template literal without breaking the surrounding template string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d078212a048332bcc323008028796b