### PR TITLE
Handle localStorage quota errors when saving catalog

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2043,9 +2043,28 @@
         // Save data to localStorage
         function saveData() {
             ensureCategoryStructure();
-            localStorage.setItem('amazoniaData', JSON.stringify(catalogData));
-            showMessage('Datos guardados correctamente', 'success');
-            updateCatalogPreview();
+            try {
+                localStorage.setItem('amazoniaData', JSON.stringify(catalogData));
+                showMessage('Datos guardados correctamente', 'success');
+                updateCatalogPreview();
+            } catch (error) {
+                const isQuotaExceeded = error instanceof DOMException && (
+                    error.name === 'QuotaExceededError' ||
+                    error.code === 22 ||
+                    error.code === 1014 ||
+                    error.name === 'NS_ERROR_DOM_QUOTA_REACHED'
+                );
+
+                if (isQuotaExceeded) {
+                    console.warn('No se pudo guardar en localStorage: cuota excedida.', error);
+                    showMessage(
+                        'El almacenamiento local está lleno. No se pudieron guardar las imágenes. Exporta tus datos y libera espacio eliminando imágenes o limpiando el almacenamiento para continuar.',
+                        'error'
+                    );
+                } else {
+                    showMessage('Ocurrió un error al guardar los datos. Inténtalo nuevamente.', 'error');
+                }
+            }
         }
 
         function validateConfigFields(fieldsToValidate = null) {


### PR DESCRIPTION
## Summary
- wrap localStorage writes in a try/catch when saving catalog data
- surface a clear warning when the storage quota is exceeded and advise how to recover
- avoid updating the preview when the save fails and log the quota error for debugging

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1be5c1bdc83329e6e8d5042df0edd