### PR TITLE
Add support for product image URLs

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -164,6 +164,8 @@
                 <div class="form-group">
                     <label>Imagen del producto:</label>
                     <input type="file" id="productImage" accept="image/*">
+                    <input type="url" id="productImageUrl" placeholder="https://raw.githubusercontent.com/...">
+                    <small style="display: block; margin-top: 0.5rem; color: #555;">Usa enlaces directos de <code>raw.githubusercontent.com</code> para imágenes alojadas en GitHub.</small>
                     <div class="image-preview" id="productImagePreviewWrapper">
                         <img id="productImagePreview" alt="Vista previa del producto" src="" />
                         <span class="image-placeholder" id="productImagePlaceholder">Sin imagen seleccionada</span>


### PR DESCRIPTION
## Summary
- add a URL input with guidance for product images sourced from GitHub
- track image file data and remote URLs independently to update previews, persistence, and catalog generation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d20b6c872883329389b5578d203ae9