### PR TITLE
Sanitize company name in catalog title

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1841,7 +1841,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${config.companyName} - Catálogo Digital</title>
+    <title>${companyNameHtml || defaultCompanyNameHtml} - Catálogo Digital</title>
     <style>
         ${getCatalogStyles()}
     </style>


### PR DESCRIPTION
## Summary
- sanitize the catalog HTML <title> tag by reusing the escaped company name that is already computed

## Testing
- node - <<'NODE'
const escapeHtml = (value) => {
  if (typeof value !== 'string') {
    return '';
  }
  return value
    .replace(/&/g, '&amp;')
    .replace(/</g, '&lt;')
    .replace(/>/g, '&gt;')
    .replace(/"/g, '&quot;')
    .replace(/'/g, '&#039;');
};
const defaultCompanyNameHtml = escapeHtml('AMAZONIA CONCRETE');
const testName = 'Selva <Brilla> "Cita" \'Única\' 😀';
const companyNameHtml = escapeHtml(testName);
const titleLine = `<title>${companyNameHtml || defaultCompanyNameHtml} - Catálogo Digital</title>`;
console.log(titleLine);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d2b31e018c8332b5d076dcdc96e2d7