### PR TITLE
Preserve product order when editing products

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1491,16 +1491,35 @@
                 catalogData.products[category] = [];
             }
             
+            let oldCategoryId = null;
+            let oldIndex = -1;
+
             if (editingProductId) {
+                // Preserve original position before removing the product
+                for (const [catId, products] of Object.entries(catalogData.products)) {
+                    const foundIndex = products.findIndex(p => p.id === editingProductId);
+                    if (foundIndex !== -1) {
+                        oldCategoryId = catId;
+                        oldIndex = foundIndex;
+                        break;
+                    }
+                }
+
                 // Remove from all categories
                 for (let cat in catalogData.products) {
                     catalogData.products[cat] = catalogData.products[cat].filter(p => p.id !== editingProductId);
                 }
             }
-            
+
+            const stayingInSameCategory = editingProductId && oldCategoryId === category;
+
             // Add to new/current category
-            catalogData.products[category].push(productData);
-            
+            if (stayingInSameCategory && oldIndex > -1 && oldIndex <= catalogData.products[category].length) {
+                catalogData.products[category].splice(oldIndex, 0, productData);
+            } else {
+                catalogData.products[category].push(productData);
+            }
+
             saveData();
             currentCategory = category;
             loadProducts();


### PR DESCRIPTION
## Summary
- track the original category and index when editing a product
- restore the updated product to its previous position when saving within the same category
- keep existing behavior of appending when the category changes

## Testing
- Not Run (front-end change)

------
https://chatgpt.com/codex/tasks/task_e_68d2f94415b083328b1f2d4923cb2211