### PR TITLE
Reset import file input after processing

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1561,38 +1561,49 @@
 
         // Handle file import
         document.getElementById('importFile').addEventListener('change', function(e) {
-            const file = e.target.files[0];
-            if (file) {
-                const reader = new FileReader();
-                reader.onload = function(event) {
-                    try {
-                        const parsed = JSON.parse(event.target.result);
+            const inputElement = e.target;
+            const file = inputElement.files && inputElement.files[0];
 
-                        if (parsed && typeof parsed === 'object') {
-                            catalogData.config = { ...defaultConfig, ...(parsed.config || {}) };
-                            catalogData.categories = Array.isArray(parsed.categories)
-                                ? parsed.categories
-                                : defaultCategories.map(category => ({ ...category }));
-                            catalogData.products = parsed.products && typeof parsed.products === 'object'
-                                ? parsed.products
-                                : createDefaultProductsMap(catalogData.categories);
-                            catalogData.categoryInfo = isPlainObject(parsed.categoryInfo) ? parsed.categoryInfo : {};
-
-                            refreshCategoriesUI({ preserveCurrent: false });
-                            renderCategoryManagerList();
-                            loadConfig();
-                            loadProducts();
-                            saveData();
-                            showMessage('Datos importados correctamente', 'success');
-                        } else {
-                            throw new Error('Formato de datos no válido');
-                        }
-                    } catch (error) {
-                        showMessage('Error al importar los datos', 'error');
-                    }
-                };
-                reader.readAsText(file);
+            if (!file) {
+                inputElement.value = '';
+                return;
             }
+
+            const reader = new FileReader();
+            reader.onload = function(event) {
+                try {
+                    const parsed = JSON.parse(event.target.result);
+
+                    if (parsed && typeof parsed === 'object') {
+                        catalogData.config = { ...defaultConfig, ...(parsed.config || {}) };
+                        catalogData.categories = Array.isArray(parsed.categories)
+                            ? parsed.categories
+                            : defaultCategories.map(category => ({ ...category }));
+                        catalogData.products = parsed.products && typeof parsed.products === 'object'
+                            ? parsed.products
+                            : createDefaultProductsMap(catalogData.categories);
+                        catalogData.categoryInfo = isPlainObject(parsed.categoryInfo) ? parsed.categoryInfo : {};
+
+                        refreshCategoriesUI({ preserveCurrent: false });
+                        renderCategoryManagerList();
+                        loadConfig();
+                        loadProducts();
+                        saveData();
+                        showMessage('Datos importados correctamente', 'success');
+                    } else {
+                        throw new Error('Formato de datos no válido');
+                    }
+                } catch (error) {
+                    showMessage('Error al importar los datos', 'error');
+                } finally {
+                    inputElement.value = '';
+                }
+            };
+            reader.onerror = function() {
+                showMessage('Error al importar los datos', 'error');
+                inputElement.value = '';
+            };
+            reader.readAsText(file);
         });
 
         // Generate Catalog


### PR DESCRIPTION
## Summary
- clear the import file input after each processing attempt to allow reselecting the same file
- reset the file input when the user cancels the dialog and on reader errors to ensure consistent cleanup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2fc452a14833282eff531a5459a55