### PR TITLE
Handle specs with additional colons

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1830,8 +1830,14 @@
 
                         // Add to product data for modal
                         const specs = product.specs ? product.specs.split('\n').map(s => {
-                            const parts = s.split(':');
-                            return parts.length === 2 ? [parts[0].trim(), parts[1].trim()] : ['', ''];
+                            const separatorIndex = typeof s === 'string' ? s.indexOf(':') : -1;
+                            if (separatorIndex === -1) {
+                                return ['', ''];
+                            }
+
+                            const label = s.slice(0, separatorIndex).trim();
+                            const value = s.slice(separatorIndex + 1).trim();
+                            return label ? [label, value] : ['', ''];
                         }).filter(s => s[0]) : [];
                         const sanitizedSpecs = specs.map(spec => [
                             escapeHtml(spec[0]),


### PR DESCRIPTION
## Summary
- ensure catalog spec parsing only splits on the first colon so URLs and other colon-containing values are preserved
- trim the value segment before sanitizing to keep formatting clean

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d31053ba748332be4fd772d598ff62