### PR TITLE
Add remove logo control in admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -80,6 +80,7 @@
                                 <img id="companyLogoPreview" alt="Vista previa del logo" src="">
                                 <span class="image-placeholder" id="companyLogoPlaceholder">Sin logo seleccionado</span>
                             </div>
+                            <button type="button" class="btn btn-secondary" id="removeLogoButton">Quitar logo</button>
                         </div>
                         <div class="form-group">
                             <label>Mensaje del footer:</label>

--- a/admin.js
+++ b/admin.js
@@ -924,6 +924,21 @@
             reader.readAsDataURL(file);
         }
 
+        function handleRemoveLogoClick() {
+            catalogData.config = catalogData.config || {};
+            catalogData.config.logoData = '';
+            updateLogoPreview(null);
+            updateCatalogPreview();
+
+            const logoInput = document.getElementById('companyLogo');
+            if (logoInput) {
+                logoInput.value = '';
+            }
+
+            saveData();
+            showMessage('Logo eliminado correctamente', 'success');
+        }
+
         function registerAdminEventHandlers() {
             const sectionButtons = document.querySelectorAll('button[data-section]');
             sectionButtons.forEach(button => {
@@ -968,6 +983,11 @@
             const saveConfigButton = document.getElementById('saveConfigButton');
             if (saveConfigButton) {
                 saveConfigButton.addEventListener('click', saveConfig);
+            }
+
+            const removeLogoButton = document.getElementById('removeLogoButton');
+            if (removeLogoButton) {
+                removeLogoButton.addEventListener('click', handleRemoveLogoClick);
             }
 
             const openProductModalButton = document.getElementById('openProductModalButton');


### PR DESCRIPTION
## Summary
- add a "Quitar logo" button next to the company logo selector in the admin panel
- implement a handler that clears the saved logo, resets the input, updates previews, and persists the change

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d311aa96148332b757577757389da1