### PR TITLE
Show admin notifications as top-right toasts

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -532,3 +532,59 @@ textarea {
     display: block;
 }
 
+.notification-container {
+    position: fixed;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 2000;
+    pointer-events: none;
+}
+
+.notification {
+    min-width: 260px;
+    max-width: 360px;
+    padding: 1rem 1.25rem;
+    border-radius: 10px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+    border-left: 5px solid transparent;
+    background: white;
+    color: #2d4a2b;
+    font-weight: 500;
+    opacity: 0;
+    transform: translateX(20px);
+    animation: notification-slide-in 0.35s ease forwards;
+    pointer-events: auto;
+}
+
+.notification.success {
+    background: #ecf9f0;
+    border-left-color: #27ae60;
+    color: #1f7a45;
+}
+
+.notification.error {
+    background: #fceaea;
+    border-left-color: #e74c3c;
+    color: #8c2f2f;
+}
+
+.notification.hide {
+    opacity: 0;
+    transform: translateX(20px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+@keyframes notification-slide-in {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+

--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="admin.css">
 </head>
 <body>
+    <div id="notificationContainer" class="notification-container" aria-live="polite"></div>
     <div class="admin-header">
         <h1>🛠️ Panel de Administración - Amazonia Concrete</h1>
         <p>Gestiona tu catálogo de productos de forma fácil y rápida</p>

--- a/admin.js
+++ b/admin.js
@@ -1614,13 +1614,31 @@
         });
 
         // Show message
-        function showMessage(message, type) {
+        function showMessage(message, type = 'success') {
             const statusMessage = document.getElementById('statusMessage');
-            statusMessage.textContent = message;
-            statusMessage.className = 'status-message ' + type;
-            
-            setTimeout(() => {
+            if (statusMessage) {
+                statusMessage.textContent = message;
                 statusMessage.className = 'status-message';
+            }
+
+            const notificationContainer = document.getElementById('notificationContainer');
+            if (!notificationContainer) {
+                return;
+            }
+
+            const notification = document.createElement('div');
+            notification.className = 'notification ' + type;
+            notification.setAttribute('role', type === 'error' ? 'alert' : 'status');
+            notification.textContent = message;
+
+            notificationContainer.appendChild(notification);
+
+            setTimeout(() => {
+                notification.classList.add('hide');
+            }, 2500);
+
+            setTimeout(() => {
+                notification.remove();
             }, 3000);
         }
 


### PR DESCRIPTION
## Summary
- add a dedicated notification container at the top-right of the admin panel
- restyle alerts as toast messages with success and error variants
- update the shared showMessage helper to render timed toast notifications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d34f7604748332a19c820578e5dd52