### PR TITLE
Add validation before saving and exporting catalog

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -150,6 +150,13 @@ input:focus, textarea:focus, select:focus {
     border-color: #6b8e68;
 }
 
+input.input-error,
+textarea.input-error,
+select.input-error {
+    border-color: #e74c3c;
+    box-shadow: 0 0 0 2px rgba(231, 76, 60, 0.15);
+}
+
 textarea {
     resize: vertical;
     min-height: 100px;


### PR DESCRIPTION
## Summary
- add client-side validation helpers for contact information before persisting
- block catalog generation until required data (contact fields and product images) are present
- surface validation feedback through status banner and inline input highlighting

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d35a82926c8332a76866d28d28e85f