### PR TITLE
Restore email icon in footer social links

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -65,6 +65,25 @@
                     </div>
 
                     <div class="config-section">
+                        <h3 style="margin-bottom: 1rem">Redes Sociales</h3>
+                        <div class="two-columns">
+                            <div class="form-group">
+                                <label>Instagram:</label>
+                                <input type="url" id="instagram" placeholder="https://www.instagram.com/amazoniaconcrete">
+                            </div>
+                            <div class="form-group">
+                                <label>Facebook:</label>
+                                <input type="url" id="facebook" placeholder="https://www.facebook.com/amazoniaconcrete">
+                            </div>
+                            <div class="form-group">
+                                <label>TikTok:</label>
+                                <input type="url" id="tiktok" placeholder="https://www.tiktok.com/@amazoniaconcrete">
+                            </div>
+                        </div>
+                        <small style="display: block; margin-top: 0.5rem; color: #555;">Ingresa enlaces completos que comiencen con <code>https://</code>.</small>
+                    </div>
+
+                    <div class="config-section">
                         <h3 style="margin-bottom: 1rem">Información de la Empresa</h3>
                         <div class="form-group">
                             <label>Nombre de la empresa:</label>

--- a/admin.js
+++ b/admin.js
@@ -2363,6 +2363,15 @@
             const headerTitleText = companyNameHtml || defaultCompanyNameHtml;
             const footerCompanyName = companyNameHtml || defaultCompanyNameHtml;
 
+            const contactButtonsMarkup = [
+                trimmedConfig.phone ? `<a id="contactPhone" class="contact-btn" href="#">📞 Llamar</a>` : '',
+                trimmedConfig.email ? `<a id="contactEmail" class="contact-btn" href="#">✉️ Email</a>` : '',
+                trimmedConfig.whatsapp ? `<a id="contactWhatsAppLink" class="contact-btn" href="#">💬 WhatsApp</a>` : '',
+                trimmedConfig.address ? `<a id="contactAddress" class="contact-btn" href="#">📍 Ubicación</a>` : ''
+            ].filter(Boolean).join('');
+
+            const contactButtonsContainer = `<div class="contact-buttons" id="footerContactButtons" style="${contactButtonsMarkup ? '' : 'display: none;'}">${contactButtonsMarkup}</div>`;
+
             const sanitizedWhatsappNumber = trimmedConfig.whatsapp.replace(/\D/g, '');
             const instagramUrlRaw = trimmedConfig.instagram;
             const facebookUrlRaw = trimmedConfig.facebook;
@@ -2496,6 +2505,7 @@
                 <h3>${footerCompanyName}</h3>
                 ${socialLinksMarkup}
                 <p>${footerMessageHtml}</p>
+                ${contactButtonsContainer}
             </div>
             <p style="margin-top: 2rem; opacity: 0.7;">© 2025 ${footerCompanyName} - Todos los derechos reservados</p>
         </div>
@@ -3010,6 +3020,32 @@
             font-size: 1.5rem;
         }
 
+        .contact-buttons {
+            display: flex;
+            justify-content: center;
+            gap: 1rem;
+            flex-wrap: wrap;
+            margin-top: 1.5rem;
+        }
+
+        .contact-btn {
+            background: rgba(255,255,255,0.1);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border: 1px solid rgba(255,255,255,0.2);
+            border-radius: 25px;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            transition: all 0.3s ease;
+        }
+
+        .contact-btn:hover {
+            background: rgba(255,255,255,0.2);
+            transform: translateY(-2px);
+        }
+
         .social-links {
             display: flex;
             justify-content: center;
@@ -3160,6 +3196,7 @@
         // Get catalog script
         function getCatalogScript(productData, config, serializer) {
             const nonDigitPatternLiteral = String.raw`/\D+/g`;
+            const phoneSanitizePatternLiteral = String.raw`/[^+\d]/g`;
             const serialize = typeof serializer === 'function'
                 ? serializer
                 : (value) => {
@@ -3248,6 +3285,8 @@
             const logoData = config.logoData || '';
             const whatsappNumber = (config.whatsapp || '').replace(${nonDigitPatternLiteral}, '');
             const emailValue = (config.email || '').trim();
+            const phoneValue = (config.phone || '').trim();
+            const addressValue = (config.address || '').trim();
             const instagramValue = (config.instagram || '').trim();
             const facebookValue = (config.facebook || '').trim();
             const tiktokValue = (config.tiktok || '').trim();
@@ -3292,6 +3331,57 @@
             const quoteButton = document.getElementById('modalQuoteButton');
             if (quoteButton) {
                 quoteButton.style.display = emailValue ? 'inline-block' : 'none';
+            }
+
+            const phoneLink = document.getElementById('contactPhone');
+            if (phoneLink) {
+                if (phoneValue) {
+                    const sanitizedPhone = phoneValue.replace(${phoneSanitizePatternLiteral}, '');
+                    if (sanitizedPhone) {
+                        phoneLink.href = \`tel:\${sanitizedPhone}\`;
+                        phoneLink.style.display = 'inline-flex';
+                    } else {
+                        phoneLink.style.display = 'none';
+                    }
+                } else {
+                    phoneLink.style.display = 'none';
+                }
+            }
+
+            const emailLink = document.getElementById('contactEmail');
+            if (emailLink) {
+                if (emailValue) {
+                    emailLink.href = \`mailto:\${emailValue}\`;
+                    emailLink.style.display = 'inline-flex';
+                } else {
+                    emailLink.style.display = 'none';
+                }
+            }
+
+            const whatsappLink = document.getElementById('contactWhatsAppLink');
+            if (whatsappLink) {
+                if (whatsappNumber) {
+                    whatsappLink.href = \`https://wa.me/\${whatsappNumber}\`;
+                    whatsappLink.style.display = 'inline-flex';
+                } else {
+                    whatsappLink.style.display = 'none';
+                }
+            }
+
+            const addressLink = document.getElementById('contactAddress');
+            if (addressLink) {
+                if (addressValue) {
+                    addressLink.href = \`https://www.google.com/maps/search/\${encodeURIComponent(addressValue)}\`;
+                    addressLink.style.display = 'inline-flex';
+                } else {
+                    addressLink.style.display = 'none';
+                }
+            }
+
+            const contactButtonsContainer = document.getElementById('footerContactButtons');
+            if (contactButtonsContainer) {
+                const hasVisibleContact = [phoneLink, emailLink, whatsappLink, addressLink].some(link => link && link.style.display !== 'none');
+                contactButtonsContainer.style.display = hasVisibleContact ? 'flex' : 'none';
             }
 
             const footerSocialContainer = document.getElementById('footerSocialLinks');

--- a/admin.js
+++ b/admin.js
@@ -4,6 +4,9 @@
             email: 'info@amazoniaconcrete.com',
             phone: '+57 300 000 0000',
             address: '',
+            instagram: '',
+            facebook: '',
+            tiktok: '',
             companyName: 'AMAZONIA CONCRETE',
             tagline: 'Naturaleza y Modernidad en Perfecta Armonía',
             footerMessage: 'Creando espacios únicos con concreto sostenible',
@@ -210,6 +213,18 @@
                 .replace(/>/g, '&gt;')
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#039;');
+        }
+
+        const SOCIAL_ICON_SVGS = {
+            whatsapp: `<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>`,
+            instagram: `<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M7.0301.084c-1.2768.0602-2.1487.264-2.911.5634-.7888.3075-1.4575.72-2.1228 1.3877-.6652.6677-1.075 1.3368-1.3802 2.127-.2954.7638-.4956 1.6365-.552 2.914-.0564 1.2775-.0689 1.6882-.0626 4.947.0062 3.2586.0206 3.6671.0825 4.9473.061 1.2765.264 2.1482.5635 2.9107.308.7889.72 1.4573 1.388 2.1228.6679.6655 1.3365 1.0743 2.1285 1.38.7632.295 1.6361.4961 2.9134.552 1.2773.056 1.6884.069 4.9462.0627 3.2578-.0062 3.668-.0207 4.9478-.0814 1.28-.0607 2.147-.2652 2.9098-.5633.7889-.3086 1.4578-.72 2.1228-1.3881.665-.6682 1.0745-1.3378 1.3795-2.1284.2957-.7632.4966-1.636.552-2.9124.056-1.2809.0692-1.6898.063-4.948-.0063-3.2583-.021-3.6668-.0817-4.9465-.0607-1.2797-.264-2.1487-.5633-2.9117-.3084-.7889-.72-1.4568-1.3876-2.1228C21.2982 1.33 20.628.9208 19.8378.6165 19.074.321 18.2017.1197 16.9244.0645 15.6471.0093 15.236-.005 11.977.0014 8.718.0076 8.31.0215 7.0301.0839m.1402 21.6932c-1.17-.0509-1.8053-.2453-2.2287-.408-.5606-.216-.96-.4771-1.3819-.895-.422-.4178-.6811-.8186-.9-1.378-.1644-.4234-.3624-1.058-.4171-2.228-.0595-1.2645-.072-1.6442-.079-4.848-.007-3.2037.0053-3.583.0607-4.848.05-1.169.2456-1.805.408-2.2282.216-.5613.4762-.96.895-1.3816.4188-.4217.8184-.6814 1.3783-.9003.423-.1651 1.0575-.3614 2.227-.4171 1.2655-.06 1.6447-.072 4.848-.079 3.2033-.007 3.5835.005 4.8495.0608 1.169.0508 1.8053.2445 2.228.408.5608.216.96.4754 1.3816.895.4217.4194.6816.8176.9005 1.3787.1653.4217.3617 1.056.4169 2.2263.0602 1.2655.0739 1.645.0796 4.848.0058 3.203-.0055 3.5834-.061 4.848-.051 1.17-.245 1.8055-.408 2.2294-.216.5604-.4763.96-.8954 1.3814-.419.4215-.8181.6811-1.3783.9-.4224.1649-1.0577.3617-2.2262.4174-1.2656.0595-1.6448.072-4.8493.079-3.2045.007-3.5825-.006-4.848-.0608M16.953 5.5864A1.44 1.44 0 1 0 18.39 4.144a1.44 1.44 0 0 0-1.437 1.4424M5.8385 12.012c.0067 3.4032 2.7706 6.1557 6.173 6.1493 3.4026-.0065 6.157-2.7701 6.1506-6.1733-.0065-3.4032-2.771-6.1565-6.174-6.1498-3.403.0067-6.156 2.771-6.1496 6.1738M8 12.0077a4 4 0 1 1 4.008 3.9921A3.9996 3.9996 0 0 1 8 12.0077"/></svg>`,
+            facebook: `<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z"/></svg>`,
+            tiktok: `<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z"/></svg>`,
+            email: `<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M2 4.75A2.75 2.75 0 0 1 4.75 2h14.5A2.75 2.75 0 0 1 22 4.75v14.5A2.75 2.75 0 0 1 19.25 22H4.75A2.75 2.75 0 0 1 2 19.25zm2.75-1.25a1.25 1.25 0 0 0-1.25 1.25v.638l8.263 5.216a.75.75 0 0 0 .774 0L20.5 5.388V4.75a1.25 1.25 0 0 0-1.25-1.25zm15.75 3.562-6.93 4.376 6.93 4.497zm-.748 11.803L12 13.461l-7.752 5.404a1.25 1.25 0 0 0 .498.085h14.504a1.25 1.25 0 0 0 .502-.09zM3.5 17.938l6.927-4.46L3.5 9.115z"/></svg>`
+        };
+
+        function getSocialIconSvg(name) {
+            return SOCIAL_ICON_SVGS[name] || '';
         }
 
         const COP_CURRENCY_FORMATTER = new Intl.NumberFormat('es-CO', {
@@ -1255,6 +1270,24 @@
             }
         }
 
+        function isValidUrl(value) {
+            if (typeof value !== 'string') {
+                return false;
+            }
+
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return false;
+            }
+
+            try {
+                const parsed = new URL(trimmed);
+                return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+            } catch (error) {
+                return false;
+            }
+        }
+
         function collectConfigValues() {
             const readValue = (id) => {
                 const element = document.getElementById(id);
@@ -1269,6 +1302,9 @@
                 email: readValue('email'),
                 phone: readValue('phone'),
                 address: readValue('address'),
+                instagram: readValue('instagram'),
+                facebook: readValue('facebook'),
+                tiktok: readValue('tiktok'),
                 companyName: readValue('companyName'),
                 tagline: readValue('tagline'),
                 footerMessage: readValue('footerMessage'),
@@ -1313,6 +1349,29 @@
                     setFieldValidationState(phoneInput, true);
                 }
             }
+
+            const socialFields = [
+                { id: 'instagram', label: 'Instagram' },
+                { id: 'facebook', label: 'Facebook' },
+                { id: 'tiktok', label: 'TikTok' }
+            ];
+
+            socialFields.forEach(({ id, label }) => {
+                const fieldValue = configValues[id] || '';
+                const input = document.getElementById(id);
+
+                if (!fieldValue) {
+                    setFieldValidationState(input, true);
+                    return;
+                }
+
+                const isValid = isValidUrl(fieldValue);
+                setFieldValidationState(input, isValid);
+
+                if (!isValid) {
+                    errors.push(`Ingresa un enlace válido para ${label} (asegúrate de incluir http:// o https://).`);
+                }
+            });
 
             if (forExport) {
                 ensureCategoryStructure();
@@ -1376,6 +1435,9 @@
             document.getElementById('email').value = catalogData.config.email || '';
             document.getElementById('phone').value = catalogData.config.phone || '';
             document.getElementById('address').value = catalogData.config.address || '';
+            document.getElementById('instagram').value = catalogData.config.instagram || '';
+            document.getElementById('facebook').value = catalogData.config.facebook || '';
+            document.getElementById('tiktok').value = catalogData.config.tiktok || '';
             document.getElementById('companyName').value = catalogData.config.companyName || '';
             document.getElementById('tagline').value = catalogData.config.tagline || '';
             document.getElementById('footerMessage').value = catalogData.config.footerMessage || '';
@@ -2169,6 +2231,9 @@
                 email: (config.email || '').trim(),
                 phone: (config.phone || '').trim(),
                 address: (config.address || '').trim(),
+                instagram: (config.instagram || '').trim(),
+                facebook: (config.facebook || '').trim(),
+                tiktok: (config.tiktok || '').trim(),
                 companyName: config.companyName || '',
                 tagline: config.tagline || '',
                 footerMessage: config.footerMessage || '',
@@ -2298,12 +2363,55 @@
             const headerTitleText = companyNameHtml || defaultCompanyNameHtml;
             const footerCompanyName = companyNameHtml || defaultCompanyNameHtml;
 
-            const contactButtons = [
-                trimmedConfig.phone ? `<a id="contactPhone" class="contact-btn" href="#">📞 Llamar</a>` : '',
-                trimmedConfig.email ? `<a id="contactEmail" class="contact-btn" href="#">✉️ Email</a>` : '',
-                trimmedConfig.whatsapp ? `<a id="contactWhatsAppLink" class="contact-btn" href="#">💬 WhatsApp</a>` : '',
-                trimmedConfig.address ? `<a id="contactAddress" class="contact-btn" href="#">📍 Ubicación</a>` : ''
-            ].filter(Boolean).join('');
+            const sanitizedWhatsappNumber = trimmedConfig.whatsapp.replace(/\D/g, '');
+            const instagramUrlRaw = trimmedConfig.instagram;
+            const facebookUrlRaw = trimmedConfig.facebook;
+            const tiktokUrlRaw = trimmedConfig.tiktok;
+            const emailAddressRaw = trimmedConfig.email;
+
+            const whatsappLinkHref = sanitizedWhatsappNumber ? `https://wa.me/${sanitizedWhatsappNumber}` : '#';
+            const whatsappLinkStyle = sanitizedWhatsappNumber ? '' : 'display: none;';
+            const instagramLinkHref = instagramUrlRaw ? escapeHtml(instagramUrlRaw) : '#';
+            const instagramLinkStyle = instagramUrlRaw ? '' : 'display: none;';
+            const facebookLinkHref = facebookUrlRaw ? escapeHtml(facebookUrlRaw) : '#';
+            const facebookLinkStyle = facebookUrlRaw ? '' : 'display: none;';
+            const tiktokLinkHref = tiktokUrlRaw ? escapeHtml(tiktokUrlRaw) : '#';
+            const tiktokLinkStyle = tiktokUrlRaw ? '' : 'display: none;';
+            const emailLinkHref = emailAddressRaw ? escapeHtml(`mailto:${emailAddressRaw}`) : '#';
+            const emailLinkStyle = emailAddressRaw ? '' : 'display: none;';
+
+            const hasSocialLinks = Boolean(
+                sanitizedWhatsappNumber ||
+                instagramUrlRaw ||
+                facebookUrlRaw ||
+                tiktokUrlRaw ||
+                emailAddressRaw
+            );
+            const socialLinksContainerStyle = hasSocialLinks ? '' : 'display: none;';
+
+            const socialLinksMarkup = `
+                <div class="social-links" id="footerSocialLinks" aria-label="Redes sociales" style="${socialLinksContainerStyle}">
+                    <a id="footerSocialWhatsApp" class="social-link social-link--whatsapp" href="${whatsappLinkHref}" target="_blank" rel="noopener noreferrer" style="${whatsappLinkStyle}">
+                        ${getSocialIconSvg('whatsapp')}
+                        <span class="sr-only">WhatsApp</span>
+                    </a>
+                    <a id="footerSocialInstagram" class="social-link social-link--instagram" href="${instagramLinkHref}" target="_blank" rel="noopener noreferrer" style="${instagramLinkStyle}">
+                        ${getSocialIconSvg('instagram')}
+                        <span class="sr-only">Instagram</span>
+                    </a>
+                    <a id="footerSocialFacebook" class="social-link social-link--facebook" href="${facebookLinkHref}" target="_blank" rel="noopener noreferrer" style="${facebookLinkStyle}">
+                        ${getSocialIconSvg('facebook')}
+                        <span class="sr-only">Facebook</span>
+                    </a>
+                    <a id="footerSocialTiktok" class="social-link social-link--tiktok" href="${tiktokLinkHref}" target="_blank" rel="noopener noreferrer" style="${tiktokLinkStyle}">
+                        ${getSocialIconSvg('tiktok')}
+                        <span class="sr-only">TikTok</span>
+                    </a>
+                    <a id="footerSocialEmail" class="social-link social-link--email" href="${emailLinkHref}" style="${emailLinkStyle}">
+                        ${getSocialIconSvg('email')}
+                        <span class="sr-only">Correo electrónico</span>
+                    </a>
+                </div>`;
 
             // Generate the complete HTML
             return `<!DOCTYPE html>
@@ -2386,8 +2494,8 @@
         <div class="footer-content">
             <div class="contact-info">
                 <h3>${footerCompanyName}</h3>
+                ${socialLinksMarkup}
                 <p>${footerMessageHtml}</p>
-                <div class="contact-buttons">${contactButtons}</div>
             </div>
             <p style="margin-top: 2rem; opacity: 0.7;">© 2025 ${footerCompanyName} - Todos los derechos reservados</p>
         </div>
@@ -2902,30 +3010,72 @@
             font-size: 1.5rem;
         }
 
-        .contact-buttons {
+        .social-links {
             display: flex;
             justify-content: center;
             gap: 1rem;
             flex-wrap: wrap;
-            margin-top: 1rem;
+            margin: 1.5rem 0 1rem;
         }
 
-        .contact-btn {
-            background: rgba(255,255,255,0.1);
-            color: white;
-            padding: 0.8rem 1.5rem;
-            border: 1px solid rgba(255,255,255,0.2);
-            border-radius: 25px;
-            text-decoration: none;
-            transition: all 0.3s ease;
+        .social-link {
+            width: 3rem;
+            height: 3rem;
+            border-radius: 50%;
             display: inline-flex;
             align-items: center;
-            gap: 0.5rem;
+            justify-content: center;
+            text-decoration: none;
+            color: #fff;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            position: relative;
+            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
         }
 
-        .contact-btn:hover {
-            background: rgba(255,255,255,0.2);
-            transform: translateY(-2px);
+        .social-link svg {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        .social-link svg path {
+            fill: currentColor;
+        }
+
+        .social-link:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .social-link--whatsapp {
+            background: #25d366;
+        }
+
+        .social-link--instagram {
+            background: linear-gradient(135deg, #f9ce34 0%, #ee2a7b 50%, #6228d7 100%);
+        }
+
+        .social-link--facebook {
+            background: #1877f2;
+        }
+
+        .social-link--tiktok {
+            background: #010101;
+        }
+
+        .social-link--email {
+            background: linear-gradient(135deg, #1d4ed8 0%, #3b82f6 100%);
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 1px, 1px);
+            white-space: nowrap;
+            border: 0;
         }
 
         /* Animations */
@@ -3010,7 +3160,6 @@
         // Get catalog script
         function getCatalogScript(productData, config, serializer) {
             const nonDigitPatternLiteral = String.raw`/\D+/g`;
-            const phoneSanitizePatternLiteral = String.raw`/[^+\d]/g`;
             const serialize = typeof serializer === 'function'
                 ? serializer
                 : (value) => {
@@ -3076,6 +3225,22 @@
             }
         });
 
+        function configureFooterLink(element, url) {
+            if (!element) {
+                return false;
+            }
+
+            const normalizedUrl = typeof url === 'string' ? url.trim() : '';
+            if (normalizedUrl) {
+                element.href = normalizedUrl;
+                element.style.display = 'inline-flex';
+                return true;
+            }
+
+            element.style.display = 'none';
+            return false;
+        }
+
         function applyConfig() {
             const config = catalogConfig || {};
             const companyName = config.companyName || '';
@@ -3083,8 +3248,9 @@
             const logoData = config.logoData || '';
             const whatsappNumber = (config.whatsapp || '').replace(${nonDigitPatternLiteral}, '');
             const emailValue = (config.email || '').trim();
-            const phoneValue = config.phone || '';
-            const addressValue = config.address || '';
+            const instagramValue = (config.instagram || '').trim();
+            const facebookValue = (config.facebook || '').trim();
+            const tiktokValue = (config.tiktok || '').trim();
 
             document.title = companyName ? \`${companyName} - Catálogo Digital\` : 'Catálogo Digital';
 
@@ -3128,45 +3294,49 @@
                 quoteButton.style.display = emailValue ? 'inline-block' : 'none';
             }
 
-            const phoneLink = document.getElementById('contactPhone');
-            if (phoneLink) {
-                const sanitizedPhone = phoneValue.replace(${phoneSanitizePatternLiteral}, '');
-                if (sanitizedPhone) {
-                    phoneLink.href = \`tel:\${sanitizedPhone}\`;
-                    phoneLink.style.display = 'inline-flex';
-                } else {
-                    phoneLink.style.display = 'none';
-                }
-            }
+            const footerSocialContainer = document.getElementById('footerSocialLinks');
+            const footerWhatsApp = document.getElementById('footerSocialWhatsApp');
+            const footerInstagram = document.getElementById('footerSocialInstagram');
+            const footerFacebook = document.getElementById('footerSocialFacebook');
+            const footerTiktok = document.getElementById('footerSocialTiktok');
+            const footerEmail = document.getElementById('footerSocialEmail');
 
-            const emailLink = document.getElementById('contactEmail');
-            if (emailLink) {
-                if (emailValue) {
-                    emailLink.href = \`mailto:\${emailValue}\`;
-                    emailLink.style.display = 'inline-flex';
-                } else {
-                    emailLink.style.display = 'none';
-                }
-            }
+            let hasFooterSocial = false;
 
-            const whatsappLink = document.getElementById('contactWhatsAppLink');
-            if (whatsappLink) {
+            if (footerWhatsApp) {
                 if (whatsappNumber) {
-                    whatsappLink.href = \`https://wa.me/\${whatsappNumber}\`;
-                    whatsappLink.style.display = 'inline-flex';
+                    footerWhatsApp.href = \`https://wa.me/\${whatsappNumber}\`;
+                    footerWhatsApp.style.display = 'inline-flex';
+                    hasFooterSocial = true;
                 } else {
-                    whatsappLink.style.display = 'none';
+                    footerWhatsApp.style.display = 'none';
                 }
             }
 
-            const addressLink = document.getElementById('contactAddress');
-            if (addressLink) {
-                if (addressValue) {
-                    addressLink.href = \`https://www.google.com/maps/search/\${encodeURIComponent(addressValue)}\`;
-                    addressLink.style.display = 'inline-flex';
+            if (configureFooterLink(footerInstagram, instagramValue)) {
+                hasFooterSocial = true;
+            }
+
+            if (configureFooterLink(footerFacebook, facebookValue)) {
+                hasFooterSocial = true;
+            }
+
+            if (configureFooterLink(footerTiktok, tiktokValue)) {
+                hasFooterSocial = true;
+            }
+
+            if (footerEmail) {
+                if (emailValue) {
+                    footerEmail.href = \`mailto:${emailValue}\`;
+                    footerEmail.style.display = 'inline-flex';
+                    hasFooterSocial = true;
                 } else {
-                    addressLink.style.display = 'none';
+                    footerEmail.style.display = 'none';
                 }
+            }
+
+            if (footerSocialContainer) {
+                footerSocialContainer.style.display = hasFooterSocial ? '' : 'none';
             }
         }
 


### PR DESCRIPTION
## Summary
- add the email contact icon back to the footer social link cluster so mail remains available alongside WhatsApp, Instagram, Facebook, and TikTok
- update the generated catalog markup and runtime preview logic to toggle the email link visibility when an address is configured
- style the new email badge to blend with the refreshed social icon treatments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ad7daafc8332b53c529cd2a99829