### PR TITLE
Fix admin page ReferenceError by removing stray markers

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1,8 +1,6 @@
 import { createCategoriesModule } from './modules/categories.js';
-codex/implement-first-code-quality-improvement
 import { createProductTemplates } from './modules/productTemplates.js';
 
- main
 
         // Default data structure
         const defaultConfig = {
@@ -99,14 +97,12 @@ import { createProductTemplates } from './modules/productTemplates.js';
             stripLegacyImageData
         });
 
-         codex/implement-first-code-quality-improvement
         const productTemplates = createProductTemplates({
             escapeHtml,
             formatCurrency: formatCurrencyCOP,
             getProductImageSource
         });
 
-         main
         const processStatusEntries = new Map();
         let processStatusCounter = 0;
         let processStatusListElement = null;


### PR DESCRIPTION
## Summary
- remove stray `codex` markers accidentally committed in `admin.js`
- clean up placeholder `main` lines that broke the module imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94bf988f883329d8e452960690031