### PR TITLE
feat: cerrar modal del catálogo con Escape

### DIFF
--- a/MEJORAS.md
+++ b/MEJORAS.md
@@ -4,6 +4,9 @@
 
 - Proporcionar equivalentes textuales a los iconos de categorías/acciones dentro del catálogo generado (por ejemplo usando `aria-label` o texto alternativo adicional) para evitar pérdida de información en usuarios con tecnologías asistivas.【F:admin.js†L1674-L1687】【F:admin.js†L2188-L2199】
 - Preparar la interfaz para traducciones (mensajes, etiquetas, notificaciones) extrayendo los literales actuales a un diccionario, ya que todo el contenido está embebido directamente en el HTML y JavaScript.【F:admin.html†L12-L147】【F:admin.js†L1987-L2110】
+- Transformar las tarjetas de producto generadas en elementos interactivos accesibles (por ejemplo, botones o enlaces) en lugar de `<div>` con manejadores `onclick`, de modo que sean enfocables y operables con teclado y lectores de pantalla.【F:admin.js†L2172-L2182】【F:admin.js†L3243-L3304】
+- Añadir etiquetas accesibles (`aria-label`) y gestión de foco al botón de cierre del modal de producto para que la opción sea identificable y navegable sin visión, además de exponer un punto de retorno al cerrar.【F:admin.js†L2320-L2328】【F:admin.js†L3265-L3311】
+- Implementar cierre mediante tecla Escape y un pequeño “focus trap” dentro del modal generado para impedir que el foco se pierda detrás de la ventana cuando se navega únicamente con teclado.【F:admin.js†L3265-L3311】
 
 ## Calidad de código y mantenibilidad
 - Dividir `admin.js` en módulos especializados (gestión de categorías, productos, configuración, exportación) para reducir el archivo monolítico de más de 2.100 líneas y facilitar las pruebas unitarias.【F:admin.js†L1-L2151】
@@ -11,4 +14,6 @@
 - Extraer las utilidades compartidas (normalización de IDs, formateo de moneda, sanitización) a un módulo independiente o carpeta `utils/` para promover su reutilización y disminuir duplicidades en validaciones.【F:admin.js†L34-L243】
 
 ## Fiabilidad de datos y exportaciones
+
+- Escapar el identificador de producto antes de inyectarlo en atributos como `onclick="openModal('...')"` para evitar roturas de HTML o potenciales inyecciones si se importa un catálogo con IDs que contengan comillas u otros caracteres especiales.【F:admin.js†L2172-L2204】
 

--- a/admin.js
+++ b/admin.js
@@ -3068,11 +3068,20 @@ import { createProductTemplates } from './modules/productTemplates.js';
 
             const modalElement = document.getElementById('productModal');
             if (modalElement) {
+                const handleModalKeydown = function(event) {
+                    if (event.key === 'Escape' && modalElement.classList.contains('active')) {
+                        event.preventDefault();
+                        closeModal();
+                    }
+                };
+
                 modalElement.addEventListener('click', function(e) {
                     if (e.target === this) {
                         closeModal();
                     }
                 });
+
+                document.addEventListener('keydown', handleModalKeydown);
             }
         });
 


### PR DESCRIPTION
## Summary
- cerrar el modal público del catálogo cuando se presiona la tecla Escape
- añadir un manejador global para detectar la tecla Escape solo mientras el modal está activo

## Testing
- not run (cambios de JavaScript sin suite automatizada)


------
https://chatgpt.com/codex/tasks/task_e_68d97ea4078083328c1cba00e84b46ac