### PR TITLE
Add multi-image support with modal carousel

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -599,6 +599,54 @@ textarea {
     align-items: center;
 }
 
+.image-url-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.image-url-item {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.product-image-url-input {
+    flex: 1;
+}
+
+.remove-image-button {
+    background: #fde2e1;
+    color: #a63a3a;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(166, 58, 58, 0.25);
+    transition: background 0.2s, color 0.2s, transform 0.2s;
+}
+
+.remove-image-button:hover {
+    background: #f8bcbc;
+    color: #7a1f1f;
+    transform: translateY(-1px);
+}
+
+.remove-image-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    background: #f5f5f5;
+    color: #999;
+    border-color: #ddd;
+}
+
+.image-add-button {
+    margin-top: 0.75rem;
+}
+
 .feature-input-group input {
     flex: 1;
 }

--- a/admin.html
+++ b/admin.html
@@ -212,9 +212,18 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="productImageUrl">Imagen del producto:</label>
-                    <input type="url" id="productImageUrl" placeholder="https://raw.githubusercontent.com/...">
-                    <small style="display: block; margin-top: 0.5rem; color: #555;">Usa enlaces directos de <code>raw.githubusercontent.com</code> para imágenes alojadas en GitHub.</small>
+                    <label for="productImageUrl">Imágenes del producto:</label>
+                    <div class="field-hint field-hint--muted">
+                        Usa enlaces directos (por ejemplo, de <code>raw.githubusercontent.com</code>) y añade todas las tomas que necesites.
+                        El catálogo mostrará flechas para avanzar entre ellas.
+                    </div>
+                    <div id="productImagesList" class="image-url-list">
+                        <div class="image-url-item">
+                            <input type="url" class="product-image-url-input" id="productImageUrl" placeholder="https://raw.githubusercontent.com/...">
+                            <button type="button" class="icon-btn remove-image-button" data-action="remove-image" aria-label="Eliminar imagen" title="Eliminar imagen">✕</button>
+                        </div>
+                    </div>
+                    <button type="button" id="addProductImageButton" class="btn btn-secondary image-add-button">➕ Añadir imagen</button>
                     <div class="image-preview" id="productImagePreviewWrapper">
                         <img id="productImagePreview" alt="Vista previa del producto" src="" />
                         <span class="image-placeholder" id="productImagePlaceholder">Sin imagen seleccionada</span>


### PR DESCRIPTION
## Summary
- allow entering multiple image URLs per product with add/remove controls in the admin form
- store and normalize image arrays when saving products and exporting data
- update the generated catalog modal to show a carousel with navigation arrows and indicators

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9a1e472908332a88a1d12d2763184