### PR TITLE
Add optional background images for catalog sections

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -151,6 +151,27 @@
                                     <span class="color-value" data-color-for="appearanceText">#2d4a2b</span>
                                 </div>
                             </div>
+                            <div class="appearance-item">
+                                <label for="appearanceBackgroundImage">Imagen de fondo del catálogo (opcional)</label>
+                                <div class="input-meta">
+                                    <input type="url" id="appearanceBackgroundImage" name="appearanceBackgroundImage" placeholder="https://ejemplo.com/fondo.jpg">
+                                    <div class="field-hint field-hint--muted">Si lo dejas vacío se mostrará el degradado configurado con los colores.</div>
+                                </div>
+                            </div>
+                            <div class="appearance-item">
+                                <label for="appearanceHeaderImage">Imagen del encabezado (opcional)</label>
+                                <div class="input-meta">
+                                    <input type="url" id="appearanceHeaderImage" name="appearanceHeaderImage" placeholder="https://ejemplo.com/encabezado.jpg">
+                                    <div class="field-hint field-hint--muted">Se mezcla con los colores del encabezado para mantener la legibilidad.</div>
+                                </div>
+                            </div>
+                            <div class="appearance-item">
+                                <label for="appearanceFooterImage">Imagen del pie de página (opcional)</label>
+                                <div class="input-meta">
+                                    <input type="url" id="appearanceFooterImage" name="appearanceFooterImage" placeholder="https://ejemplo.com/footer.jpg">
+                                    <div class="field-hint field-hint--muted">Úsalo para personalizar el fondo del cierre del catálogo.</div>
+                                </div>
+                            </div>
                         </div>
                         <button type="button" class="btn btn-secondary" id="resetAppearanceButton">Restaurar colores de fábrica</button>
                     </div>


### PR DESCRIPTION
## Summary
- add admin controls to capture background image URLs for the catalog body, header, and footer
- propagate the new appearance settings through configuration handling and validation
- update the catalog generator to layer the images with existing color gradients using sanitised CSS

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e042f3dda88332af1f028b7aea9529